### PR TITLE
feat: add duration metrics to indexing, search, and reranking logs

### DIFF
--- a/src/application/use_cases/index_repository.rs
+++ b/src/application/use_cases/index_repository.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Instant;
 
 use ignore::WalkBuilder;
 use tracing::{debug, info, warn};
@@ -107,6 +108,8 @@ impl IndexRepositoryUseCase {
 
         info!("Indexing repository: {} at {}", repo_name, path_str);
 
+        let start_time = Instant::now();
+
         let mut file_count = 0u64;
         let mut chunk_count = 0u64;
         let mut file_hashes = Vec::new();
@@ -200,9 +203,10 @@ impl IndexRepositoryUseCase {
             .update_stats(repository.id(), chunk_count, file_count)
             .await?;
 
+        let duration = start_time.elapsed();
         info!(
-            "Indexing complete: {} files, {} chunks",
-            file_count, chunk_count
+            "Indexing complete: {} files, {} chunks in {:.2}s",
+            file_count, chunk_count, duration.as_secs_f64()
         );
 
         self.repository_repo
@@ -216,6 +220,8 @@ impl IndexRepositoryUseCase {
         absolute_path: &Path,
         repository: &Repository,
     ) -> Result<Repository, DomainError> {
+        let start_time = Instant::now();
+
         // Load existing file hashes
         let existing_hashes = self
             .file_hash_repo
@@ -396,9 +402,10 @@ impl IndexRepositoryUseCase {
             .update_stats(repository.id(), total_chunk_count, total_file_count)
             .await?;
 
+        let duration = start_time.elapsed();
         info!(
-            "Incremental indexing complete: processed {} files ({} new chunks)",
-            processed_count, new_chunk_count
+            "Incremental indexing complete: processed {} files ({} new chunks) in {:.2}s",
+            processed_count, new_chunk_count, duration.as_secs_f64()
         );
 
         self.repository_repo

--- a/src/application/use_cases/search_code.rs
+++ b/src/application/use_cases/search_code.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Instant;
 
 use tracing::{debug, info};
 
@@ -30,6 +31,8 @@ impl SearchCodeUseCase {
 
     pub async fn execute(&self, query: SearchQuery) -> Result<Vec<SearchResult>, DomainError> {
         info!("Searching for: {}", query.query());
+
+        let start_time = Instant::now();
 
         let query_embedding = self.embedding_service.embed_query(query.query()).await?;
 
@@ -71,7 +74,8 @@ impl SearchCodeUseCase {
                 .await?;
         }
 
-        info!("Found {} results", results.len());
+        let duration = start_time.elapsed();
+        info!("Found {} results in {:.2}s", results.len(), duration.as_secs_f64());
 
         Ok(results)
     }

--- a/src/connector/adapter/ort_reranking.rs
+++ b/src/connector/adapter/ort_reranking.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use async_trait::async_trait;
 use ort::{
@@ -195,6 +196,8 @@ impl RerankingService for OrtReranking {
 
         info!("Reranking {} results for query: {}", results.len(), query);
 
+        let start_time = Instant::now();
+
         let documents: Vec<String> = results.iter().map(format_document_for_reranking).collect();
 
         let doc_refs: Vec<&str> = documents.iter().map(|s| s.as_str()).collect();
@@ -222,7 +225,8 @@ impl RerankingService for OrtReranking {
             reranked.truncate(k);
         }
 
-        debug!("Reranking complete, returning {} results", reranked.len());
+        let duration = start_time.elapsed();
+        info!("Reranking complete: {} results in {:.2}s", reranked.len(), duration.as_secs_f64());
 
         Ok(reranked)
     }


### PR DESCRIPTION
Add timing measurements using std::time::Instant to log the duration of:
- Full indexing operations
- Incremental indexing operations
- Search operations
- Reranking operations

This enables benchmarking of future feature changes.

https://claude.ai/code/session_014a6Fhv3sis85DppWCbqzFf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Observability & Performance Monitoring**
  * Indexing workflows now log operation duration for both initial and incremental processing cycles to improve operational insights.
  * Search execution reports elapsed time metrics alongside result counts in application logs.
  * Reranking operations include completion timing and result statistics in log messages for enhanced system visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->