### PR TITLE
refactor: reduce log verbosity by changing technical logs to debug level

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,49 @@ codesearch search "validation" --language rust --min-score 0.7
 - Downloaded automatically from HuggingFace Hub on first use
 - No API key or external service required
 
+## Logging
+
+CodeSearch uses structured logging with sensible defaults to keep output clean while providing detailed information when needed.
+
+### Default Behavior
+
+By default, only application-level logs are shown:
+- Indexing progress and completion
+- Search queries and results
+- Reranking operations
+- Repository deletion
+
+Logs from external dependencies (ONNX runtime, tokenizers, database drivers, etc.) are suppressed to reduce noise.
+
+### Verbose Mode
+
+Use `-v` or `--verbose` to enable debug-level logging for troubleshooting:
+
+```bash
+codesearch -v index /path/to/repo
+codesearch -v search "authentication"
+```
+
+This shows additional details like:
+- File processing progress
+- Model initialization
+- Storage backend configuration
+
+### Advanced: External Crate Logs
+
+To debug issues with external dependencies, use the `RUST_LOG` environment variable:
+
+```bash
+# Debug ONNX runtime issues
+RUST_LOG=warn,codesearch=info,ort=debug codesearch index /path/to/repo
+
+# Debug database issues
+RUST_LOG=warn,codesearch=info,duckdb=debug codesearch search "query"
+
+# Debug everything (very verbose)
+RUST_LOG=debug codesearch index /path/to/repo
+```
+
 ## Development
 
 ```bash

--- a/src/connector/adapter/chroma_vector_repository.rs
+++ b/src/connector/adapter/chroma_vector_repository.rs
@@ -6,7 +6,7 @@ use chromadb::collection::{CollectionEntries, GetOptions, QueryOptions};
 use chromadb::ChromaCollection;
 use serde_json::Map;
 use tokio::sync::Mutex;
-use tracing::{debug, info};
+use tracing::debug;
 
 use crate::application::VectorRepository;
 use crate::domain::{CodeChunk, DomainError, Embedding, SearchQuery, SearchResult};
@@ -27,7 +27,7 @@ impl ChromaVectorRepository {
         .await
         .map_err(|e| DomainError::internal(format!("Failed to connect to ChromaDB: {}", e)))?;
 
-        info!("Connected to ChromaDB at {}", url);
+        debug!("Connected to ChromaDB at {}", url);
 
         let collection = client
             .get_or_create_collection(collection_name, None)
@@ -36,7 +36,7 @@ impl ChromaVectorRepository {
                 DomainError::internal(format!("Failed to get/create collection: {}", e))
             })?;
 
-        info!("Using ChromaDB collection: {}", collection_name);
+        debug!("Using ChromaDB collection: {}", collection_name);
 
         Ok(Self {
             client,

--- a/src/connector/adapter/ort_embedding.rs
+++ b/src/connector/adapter/ort_embedding.rs
@@ -7,7 +7,7 @@ use ort::{
     value::Tensor,
 };
 use tokenizers::Tokenizer;
-use tracing::{debug, info};
+use tracing::debug;
 
 use crate::application::EmbeddingService;
 use crate::domain::{CodeChunk, DomainError, Embedding, EmbeddingConfig};
@@ -25,7 +25,7 @@ pub struct OrtEmbedding {
 impl OrtEmbedding {
     pub fn new(model_id: Option<&str>) -> Result<Self, DomainError> {
         let model_id = model_id.unwrap_or(DEFAULT_MODEL_ID);
-        info!(
+        debug!(
             "Initializing ORT embedding service with model: {}",
             model_id
         );
@@ -54,7 +54,7 @@ impl OrtEmbedding {
         tokenizer_path: PathBuf,
         model_name: &str,
     ) -> Result<Self, DomainError> {
-        info!("Loading ONNX model from: {:?}", model_path);
+        debug!("Loading ONNX model from: {:?}", model_path);
 
         let session = Session::builder()
             .map_err(|e| DomainError::internal(format!("Failed to create session builder: {}", e)))?

--- a/src/connector/adapter/ort_reranking.rs
+++ b/src/connector/adapter/ort_reranking.rs
@@ -27,7 +27,7 @@ pub struct OrtReranking {
 impl OrtReranking {
     pub fn new(model_id: Option<&str>) -> Result<Self, DomainError> {
         let model_id = model_id.unwrap_or(DEFAULT_MODEL_ID);
-        info!(
+        debug!(
             "Initializing ORT reranking service with model: {}",
             model_id
         );
@@ -56,7 +56,7 @@ impl OrtReranking {
         tokenizer_path: PathBuf,
         model_name: &str,
     ) -> Result<Self, DomainError> {
-        info!("Loading ONNX model from: {:?}", model_path);
+        debug!("Loading ONNX model from: {:?}", model_path);
 
         let session = Session::builder()
             .map_err(|e| DomainError::internal(format!("Failed to create session builder: {}", e)))?


### PR DESCRIPTION
Move infrastructure/initialization logs from info to debug level:
- ORT embedding service initialization and model loading
- ORT reranking service initialization and model loading
- Container service initialization (mock/ONNX services, storage backends)
- ChromaDB connection and collection logs

Application-level logs remain at info level:
- Indexing progress and completion
- Search queries and results
- Reranking operations
- Repository deletion

Use -v flag to see debug logs when needed.

https://claude.ai/code/session_014a6Fhv3sis85DppWCbqzFf