### PR TITLE
feat: add multi-language repository support

### DIFF
--- a/src/application/interfaces/metadata_repository.rs
+++ b/src/application/interfaces/metadata_repository.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 
-use crate::domain::{DomainError, Repository};
+use crate::domain::{DomainError, LanguageStats, Repository};
 
 /// Persistence for repository metadata.
 #[async_trait]
@@ -20,5 +22,11 @@ pub trait MetadataRepository: Send + Sync {
         id: &str,
         chunk_count: u64,
         file_count: u64,
+    ) -> Result<(), DomainError>;
+
+    async fn update_languages(
+        &self,
+        id: &str,
+        languages: HashMap<String, LanguageStats>,
     ) -> Result<(), DomainError>;
 }

--- a/src/connector/api/controller/repository_controller.rs
+++ b/src/connector/api/controller/repository_controller.rs
@@ -63,12 +63,23 @@ impl<'a> RepositoryController<'a> {
     }
 
     fn format_index_success(&self, repo: &Repository) -> String {
-        format!(
+        let mut output = format!(
             "Successfully indexed repository: {} ({} files, {} chunks)",
             repo.name(),
             repo.file_count(),
             repo.chunk_count()
-        )
+        );
+
+        if !repo.languages().is_empty() {
+            let langs: Vec<_> = repo
+                .languages()
+                .iter()
+                .map(|(lang, stats)| format!("{}: {} files", lang, stats.file_count))
+                .collect();
+            output.push_str(&format!("\nLanguages: {}", langs.join(", ")));
+        }
+
+        output
     }
 
     fn format_repository_list(&self, repos: &[Repository]) -> String {
@@ -85,6 +96,14 @@ impl<'a> RepositoryController<'a> {
                 repo.file_count(),
                 repo.chunk_count()
             ));
+            if !repo.languages().is_empty() {
+                let langs: Vec<_> = repo
+                    .languages()
+                    .iter()
+                    .map(|(lang, stats)| format!("{}: {} files", lang, stats.file_count))
+                    .collect();
+                output.push_str(&format!("    Languages: {}\n", langs.join(", ")));
+            }
             let ns_display = repo.namespace().unwrap_or("(none)");
             output.push_str(&format!(
                 "    Store: {}, Namespace: {}\n",


### PR DESCRIPTION
Track language statistics (file count, chunk count) per programming language for each repository. Changes include:

- Add LanguageStats struct and languages field to Repository domain model
- Add languages JSON column to DuckDB repositories table with migration
- Track language stats during full and incremental indexing
- Add update_languages method to MetadataRepository trait
- Update index and list output to show language breakdown

Example output:
  Successfully indexed repository: my-repo (100 files, 500 chunks) Languages: rust: 50 files, python: 30 files, javascript: 20 files

https://claude.ai/code/session_014a6Fhv3sis85DppWCbqzFf