### PR TITLE
feat: expose search as mcp server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,12 @@ tokenizers = "0.21"
 hf-hub = "0.4"
 ndarray = "0.16"
 
+# MCP Server
+rmcp = { version = "0.14", features = ["server", "transport-io", "transport-streamable-http-server", "transport-streamable-http-server-session", "macros"] }
+schemars = "1.0"
+axum = "0.8"
+tokio-util = "0.7"
+
 [dev-dependencies]
 tempfile = "3.10"
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -36,4 +36,11 @@ pub enum Commands {
     },
 
     Stats,
+
+    /// Start MCP (Model Context Protocol) server for integration with AI tools
+    Mcp {
+        /// Run as HTTP server on specified port (e.g., --http 8080)
+        #[arg(long)]
+        http: Option<u16>,
+    },
 }

--- a/src/connector/adapter/mcp/mod.rs
+++ b/src/connector/adapter/mcp/mod.rs
@@ -1,0 +1,5 @@
+mod server;
+mod tools;
+
+pub use server::{CodesearchMcpServer, SearchToolInput};
+pub use tools::SearchResultOutput;

--- a/src/connector/adapter/mcp/server.rs
+++ b/src/connector/adapter/mcp/server.rs
@@ -1,0 +1,129 @@
+use std::sync::Arc;
+
+use rmcp::handler::server::tool::ToolRouter;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{
+    CallToolResult, Content, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo,
+};
+use rmcp::tool;
+use rmcp::tool_handler;
+use rmcp::tool_router;
+use rmcp::ErrorData as McpError;
+use rmcp::ServerHandler;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::connector::api::Container;
+use crate::domain::SearchQuery;
+
+use super::tools::SearchResultOutput;
+
+fn default_limit() -> usize {
+    10
+}
+
+/// Input parameters for the search_code tool
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SearchToolInput {
+    /// Natural language query describing the code you're looking for
+    pub query: String,
+
+    /// Maximum number of results to return (default: 10)
+    #[serde(default = "default_limit")]
+    pub limit: usize,
+
+    /// Minimum relevance score threshold (0.0 to 1.0)
+    pub min_score: Option<f32>,
+
+    /// Filter results by programming languages (e.g., ["rust", "python"])
+    pub languages: Option<Vec<String>>,
+
+    /// Filter results by repository IDs
+    pub repositories: Option<Vec<String>>,
+}
+
+/// MCP Server that exposes codesearch functionality
+#[derive(Clone)]
+pub struct CodesearchMcpServer {
+    container: Arc<Container>,
+    tool_router: ToolRouter<Self>,
+}
+
+#[tool_router]
+impl CodesearchMcpServer {
+    pub fn new(container: Arc<Container>) -> Self {
+        Self {
+            container,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    /// Search for code using semantic similarity. Returns relevant code snippets matching a natural language query.
+    /// Use this to find functions, classes, implementations, or any code constructs by describing what you're looking for.
+    #[tool(name = "search_code")]
+    async fn search_code(
+        &self,
+        params: Parameters<SearchToolInput>,
+    ) -> Result<CallToolResult, McpError> {
+        let input = params.0;
+
+        // Build SearchQuery from input
+        let mut query = SearchQuery::new(&input.query).with_limit(input.limit);
+
+        if let Some(score) = input.min_score {
+            query = query.with_min_score(score);
+        }
+        if let Some(langs) = input.languages {
+            query = query.with_languages(langs);
+        }
+        if let Some(repos) = input.repositories {
+            query = query.with_repositories(repos);
+        }
+
+        // Execute search
+        let use_case = self.container.search_use_case();
+        let results = use_case.execute(query).await.map_err(|e| {
+            McpError::internal_error(format!("Search failed: {}", e), None)
+        })?;
+
+        // Convert to output format
+        let outputs: Vec<SearchResultOutput> = results
+            .iter()
+            .map(|r| SearchResultOutput {
+                file_path: r.chunk().file_path().to_string(),
+                start_line: r.chunk().start_line(),
+                end_line: r.chunk().end_line(),
+                score: r.score(),
+                language: r.chunk().language().to_string(),
+                node_type: r.chunk().node_type().to_string(),
+                symbol_name: r.chunk().symbol_name().map(String::from),
+                content: r.chunk().content().to_string(),
+                repository_id: r.chunk().repository_id().to_string(),
+            })
+            .collect();
+
+        // Return as JSON content
+        let json = serde_json::to_string_pretty(&outputs).map_err(|e| {
+            McpError::internal_error(format!("Failed to serialize results: {}", e), None)
+        })?;
+
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for CodesearchMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            protocol_version: ProtocolVersion::V_2024_11_05,
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            server_info: Implementation::from_build_env(),
+            instructions: Some(
+                "Semantic code search server. Use the search_code tool to find relevant code \
+                 snippets by describing what you're looking for in natural language. The tool \
+                 searches across indexed repositories using ML embeddings for semantic similarity."
+                    .into(),
+            ),
+        }
+    }
+}

--- a/src/connector/adapter/mcp/tools.rs
+++ b/src/connector/adapter/mcp/tools.rs
@@ -1,0 +1,56 @@
+use schemars::JsonSchema;
+use serde::Serialize;
+
+/// A single search result returned by the search_code tool
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct SearchResultOutput {
+    /// Path to the file containing the code
+    pub file_path: String,
+
+    /// Starting line number (1-indexed)
+    pub start_line: u32,
+
+    /// Ending line number (1-indexed)
+    pub end_line: u32,
+
+    /// Relevance score (0.0 to 1.0)
+    pub score: f32,
+
+    /// Programming language of the code
+    pub language: String,
+
+    /// Type of code construct (function, class, struct, etc.)
+    pub node_type: String,
+
+    /// Name of the symbol (function name, class name, etc.)
+    pub symbol_name: Option<String>,
+
+    /// The actual code content
+    pub content: String,
+
+    /// Repository ID this code belongs to
+    pub repository_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_search_result_output_serialization() {
+        let output = SearchResultOutput {
+            file_path: "src/lib.rs".to_string(),
+            start_line: 10,
+            end_line: 20,
+            score: 0.95,
+            language: "rust".to_string(),
+            node_type: "function".to_string(),
+            symbol_name: Some("authenticate".to_string()),
+            content: "fn authenticate() {}".to_string(),
+            repository_id: "repo-123".to_string(),
+        };
+        let json = serde_json::to_string(&output).unwrap();
+        assert!(json.contains("authenticate"));
+        assert!(json.contains("src/lib.rs"));
+    }
+}

--- a/src/connector/adapter/mod.rs
+++ b/src/connector/adapter/mod.rs
@@ -3,6 +3,7 @@ mod duckdb_file_hash_repository;
 mod duckdb_metadata_repository;
 mod duckdb_vector_repository;
 mod in_memory_vector_repository;
+pub mod mcp;
 mod mock_embedding;
 mod mock_reranking;
 mod ort_embedding;

--- a/src/connector/api/router.rs
+++ b/src/connector/api/router.rs
@@ -37,6 +37,7 @@ impl<'a> Router<'a> {
             Commands::List => self.repository_controller.list().await,
             Commands::Delete { id_or_path } => self.repository_controller.delete(id_or_path).await,
             Commands::Stats => self.search_controller.stats().await,
+            Commands::Mcp { .. } => unreachable!("MCP command is handled separately in main"),
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Model Context Protocol (MCP) server support enabling integration with AI tools
  * MCP server can operate in stdio mode (default) or HTTP mode via `--http` flag with configurable port
  * Exposed semantic code search capability through MCP, including filtering by languages, repositories, score thresholds, and result limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->