### PR TITLE
perf: optimize reranking with log-based candidate scaling and score filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ CodeSearch supports optional reranking to improve search result relevance using 
 
 ### How It Works
 
-1. Initial vector search retrieves candidates using logarithmic scaling: `num + num × ⌈ln(num)⌉` (defaults to 20 base candidates when `num ≤ 10`)
+1. Initial vector search retrieves candidates using inverse-log scaling: `num + ⌈num / ln(num)⌉` (defaults to 20 base candidates when `num ≤ 10`)
 2. Candidates with vector similarity score below 0.1 are excluded (too irrelevant to benefit from reranking)
 3. A cross-encoder model (mxbai-rerank-xsmall-v1) reranks remaining candidates based on query-document relevance
 4. Top `num` reranked results are returned

--- a/docs/features/search.md
+++ b/docs/features/search.md
@@ -48,7 +48,7 @@ codesearch search "error handling" --num 20
 Enable cross-encoder reranking to improve result quality:
 
 ```bash
-# Basic reranking (fetches ~20 candidates via log-based scaling, returns top 10)
+# Basic reranking (fetches ~27 candidates via inverse-log scaling, returns top 10)
 codesearch search "error handling"
 
 # Reranking with custom result count
@@ -59,7 +59,7 @@ codesearch search "validation" --no-rerank
 ```
 
 **How reranking works:**
-- Fetches candidates from vector search using a logarithmic scaling formula: `num + num × ⌈ln(num)⌉` (defaults to 20 base candidates when `num ≤ 10`)
+- Fetches candidates from vector search using an inverse-log formula: `num + ⌈num / ln(num)⌉` (defaults to 20 base candidates when `num ≤ 10`)
 - Filters out candidates with a vector similarity score below 0.1 (too irrelevant to benefit from reranking)
 - Rescores remaining candidates using a cross-encoder model (mxbai-rerank-xsmall-v1)
 - Returns top `num` results by relevance score


### PR DESCRIPTION
Replace the fixed 100-candidate fetch with a logarithmic formula
(num + num × ⌈ln(num)⌉) that scales proportionally without overwhelming
the cross-encoder. Default base is now 20 instead of 100 when the user
doesn't specify a result count. Also filter out candidates with vector
similarity score < 0.1 before reranking since they're unlikely to
resurface and just add latency.

https://claude.ai/code/session_011fcB4fAGa9JYoExjKLLqWn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced search reranking with improved candidate selection strategy using logarithmic scaling.
  * Added similarity score filtering to exclude low-quality candidates during reranking.

* **Documentation**
  * Updated reranking documentation to reflect new algorithm parameters and filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->