### PR TITLE
docs: update documentation to reflect v0.6.0 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,12 @@
 
 ## Unreleased
 
-### Features
-
-* add `--format` flag to search command with `text`, `json`, and `vimgrep` output modes
-* add Telescope extension for Neovim (`ide/nvim/`) with semantic search picker and file preview
-
 ## [0.6.0](https://github.com/ArtemisMucaj/codesearch/compare/v0.5.0...v0.6.0) (2026-02-16)
 
 
 ### Features
 
+* add `--format` flag to search command with `text`, `json`, and `vimgrep` output modes ([3c87058](https://github.com/ArtemisMucaj/codesearch/commit/3c870588428f18b2006a32f737879dd68fc920a1))
 * add call graph indexing to track symbol references ([ef4c6ec](https://github.com/ArtemisMucaj/codesearch/commit/ef4c6ec2c75a2b574449e6672182c93bb8b655c3))
 * add skill for codesearch CLI ([#42](https://github.com/ArtemisMucaj/codesearch/issues/42)) ([e228bde](https://github.com/ArtemisMucaj/codesearch/commit/e228bde8d5b5cffcc10c6caa22c585dbc57c951d))
 * add Telescope/Neovim integration for semantic code search ([#40](https://github.com/ArtemisMucaj/codesearch/issues/40)) ([3c87058](https://github.com/ArtemisMucaj/codesearch/commit/3c870588428f18b2006a32f737879dd68fc920a1))

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A semantic code search tool that indexes code repositories using embeddings and 
 
 - **Semantic search**: uses ML embeddings to find semantically similar code
 - **AST-aware**: parses code using tree-sitter for structure-aware indexing
-- **Multi-language support**: supports Rust, Python, JavaScript, TypeScript, Go
+- **Multi-language support**: supports Rust, Python, JavaScript, TypeScript, Go, HCL, PHP, C++
 - **Persistent storage**: DuckDB with VSS (Vector Similarity Search) acceleration
 - **Flexible backends**: supports ChromaDB and in-memory storage
 - **Fast indexing**: efficient batch processing with ONNX embedding generation
@@ -16,9 +16,9 @@ A semantic code search tool that indexes code repositories using embeddings and 
 This project follows Domain-Driven Design (DDD) principles:
 
 ```
-crates/
+src/
 ├── domain/
-|── application/
+├── application/
 ├── connector/
 └── cli/
 ```
@@ -65,6 +65,12 @@ codesearch list
 # Delete a repository by name or path
 codesearch delete my-repo
 codesearch delete /path/to/repo
+
+# Start MCP server (stdio, for AI tool integration)
+codesearch mcp
+
+# Start MCP server over HTTP
+codesearch mcp --http 8080
 ```
 
 ### Configuration Options
@@ -72,7 +78,7 @@ codesearch delete /path/to/repo
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--data-dir` | `~/.codesearch` | Directory for DuckDB database files |
-| `--namespace` | `main` | DuckDB schema namespace for vector storage |
+| `--namespace` | `search` | DuckDB schema namespace for vector storage |
 | `--chroma-url` | (optional) | Use ChromaDB instead of DuckDB for vectors |
 | `--memory-storage` | `false` | Use in-memory storage (no persistence) |
 | `--mock-embeddings` | `false` | Use mock embeddings (for testing) |
@@ -178,6 +184,30 @@ require("telescope").setup({
 # Load results directly into Neovim's quickfix list
 codesearch search "error handling" --format vimgrep | nvim -q /dev/stdin
 ```
+
+### MCP Server
+
+CodeSearch can run as a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server, allowing AI tools (Claude, Cursor, etc.) to search your codebase semantically.
+
+**Stdio mode** (default, for local AI tool integration):
+
+```bash
+codesearch mcp
+```
+
+**HTTP mode** (for network-accessible deployments):
+
+```bash
+# Listen on localhost:8080
+codesearch mcp --http 8080
+
+# Listen on all interfaces (public)
+codesearch mcp --http 8080 --public
+```
+
+The HTTP server exposes the MCP endpoint at `/mcp`.
+
+**Exposed tool**: `search_code` — accepts `query`, `limit`, `min_score`, `languages`, and `repositories` parameters.
 
 ### Storage Backends
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -16,6 +16,7 @@ graph TB
             Search[Search]
             List[List]
             Delete[Delete]
+            CallGraph[CallGraph]
         end
         subgraph Ports["Interfaces / Ports"]
             VectorRepo[VectorRepository]
@@ -38,11 +39,15 @@ graph TB
         subgraph Adapters["Adapters"]
             DuckDBMeta[DuckdbMetadataRepository]
             DuckDBVec[DuckdbVectorRepository]
+            DuckDBCallGraph[DuckdbCallGraphRepository]
+            DuckDBFileHash[DuckdbFileHashRepository]
             Chroma[ChromaVectorRepository]
             InMemory[InMemoryVectorRepository]
             Ort[OrtEmbedding]
+            OrtRerank[OrtReranking]
             Mock[MockEmbedding]
             TreeSitter[TreeSitterParser]
+            MCP[McpServer]
         end
     end
 
@@ -69,6 +74,7 @@ Contains use cases and interface definitions (ports):
 - **SearchCodeUseCase**: Performs semantic search
 - **ListRepositoriesUseCase**: Lists indexed repositories
 - **DeleteRepositoryUseCase**: Removes a repository from the index
+- **CallGraphUseCase**: Tracks and queries symbol references (callers, callees, cross-repo lookups)
 
 **Interfaces/Ports** (`src/application/interfaces/`):
 - **VectorRepository**: Interface for vector storage and similarity search operations
@@ -97,11 +103,15 @@ Implements the application interfaces with concrete adapters:
 **Adapters** (`src/connector/adapter/`):
 - **DuckdbMetadataRepository**: DuckDB implementation of MetadataRepository; stores repository metadata, chunks, and statistics
 - **DuckdbVectorRepository**: DuckDB implementation of VectorRepository with VSS (Vector Similarity Search) acceleration using HNSW indexes and cosine distance
+- **DuckdbCallGraphRepository**: DuckDB implementation storing symbol references (callers, callees, reference kind, location) with indexes for efficient lookup
+- **DuckdbFileHashRepository**: DuckDB implementation storing SHA-256 file hashes for incremental indexing change detection
 - **ChromaVectorRepository**: ChromaDB implementation of VectorRepository for remote vector storage
 - **InMemoryVectorRepository**: In-memory implementation of VectorRepository for testing/ephemeral indexing
 - **OrtEmbedding**: ONNX Runtime implementation of EmbeddingService using sentence-transformers models
+- **OrtReranking**: ONNX Runtime cross-encoder implementation for reranking search results by query-document relevance
 - **MockEmbedding**: Mock implementation of EmbeddingService for testing
 - **TreeSitterParser**: Tree-sitter based implementation of ParserService for multi-language code parsing
+- **CodesearchMcpServer**: Model Context Protocol server exposing the `search_code` tool over stdio or HTTP
 
 ## Data Flow
 

--- a/docs/features/getting-started.md
+++ b/docs/features/getting-started.md
@@ -97,6 +97,21 @@ codesearch delete abc123
 codesearch delete /path/to/your/project
 ```
 
+### Start the MCP Server
+
+Run CodeSearch as a [Model Context Protocol](https://modelcontextprotocol.io/) server for AI tool integration:
+
+```bash
+# Stdio mode (default, for Claude Desktop / Cursor / etc.)
+codesearch mcp
+
+# HTTP mode on a specific port
+codesearch mcp --http 8080
+
+# HTTP mode accessible on all interfaces
+codesearch mcp --http 8080 --public
+```
+
 ## Configuration
 
 ### Data Directory
@@ -121,8 +136,9 @@ Codesearch uses **semantic vector search**:
 
 1. Your query is converted to a 384-dimensional embedding
 2. The DuckDB VSS extension finds semantically similar code using HNSW indexes
-3. Results are ranked by cosine similarity (0.0 to 1.0)
-4. Filters can be applied by language, node type, repository, or minimum score
+3. A cross-encoder reranker (mxbai-rerank-xsmall-v1) rescores candidates for higher relevance (enabled by default, disable with `--no-rerank`)
+4. Results are ranked by cosine similarity (0.0 to 1.0) or reranking score
+5. Filters can be applied by language, node type, repository, or minimum score
 
 **Why VSS (Vector Similarity Search)?**
 - ✓ Finds conceptually similar code, not just keyword matches
@@ -137,6 +153,9 @@ Codesearch uses **semantic vector search**:
 - JavaScript (`.js`, `.jsx`, `.mjs`, `.cjs`)
 - TypeScript (`.ts`, `.tsx`)
 - Go (`.go`)
+- HCL (`.hcl`, `.tf`)
+- PHP (`.php`)
+- C++ (`.cpp`, `.cc`, `.cxx`, `.h`, `.hpp`)
 
 ## What Gets Indexed
 

--- a/docs/features/indexing.md
+++ b/docs/features/indexing.md
@@ -48,6 +48,9 @@ flowchart TB
 | JavaScript | function, class, method, arrow_function       |
 | TypeScript | function, class, method, arrow_function       |
 | Go         | function, method, type                        |
+| HCL        | block, attribute                              |
+| PHP        | function, class, method                       |
+| C++        | function, class, struct, method               |
 
 ### 4. Embedding Generation
 
@@ -197,8 +200,9 @@ User Query
 Embed Query (384 dimensions)
     ↓
 Vector Search (retrieve candidates)
-    ├─ If num ≤ 10: fetch 100 candidates
-    └─ If num > 10: fetch num × 10 candidates
+    └─ Fetch num + ⌈num / ln(num)⌉ candidates (defaults to 20 base when num ≤ 10)
+    ↓
+Filter (exclude candidates with vector score < 0.1)
     ↓
 Reranking (mxbai-rerank-xsmall-v1)
     ├─ Score each candidate against query

--- a/docs/features/search.md
+++ b/docs/features/search.md
@@ -24,7 +24,7 @@ flowchart TB
 1. **Query Embedding**: Input text is embedded using the same model as indexing (384 dimensions)
 2. **VSS Search**: DuckDB's Vector Similarity Search uses HNSW index to find similar vectors (fast approximate nearest neighbors)
 3. **Filtering**: Results filtered by language, node type, repository, and minimum score threshold
-4. **Reranking**: Enabled by defaylt, skip using `--no-rerank`
+4. **Reranking**: Enabled by default, skip using `--no-rerank`
 5. **Details Fetch**: Full code chunks reconstructed from DuckDB
 6. **Ranking**: Results ranked by cosine distance (0.0 = opposite, 1.0 = identical) or reranking score if enabled
 


### PR DESCRIPTION
- CHANGELOG: move --format flag and Telescope extension entries from
  Unreleased into the 0.6.0 release section where they belong
- README: fix architecture directory layout (src/ not crates/), add
  HCL/PHP/C++ to language support, fix --namespace default (search not
  main), add mcp command and MCP server section
- docs/features/getting-started: add HCL/PHP/C++ to supported languages,
  add mcp command, add reranking step to "How Search Works"
- docs/features/search: fix typo "defaylt" -> "default"
- docs/features/indexing: fix reranking candidate formula (inverse-log
  scaling) and add low-score filter step; add HCL/PHP/C++ node types
- docs/architecture/overview: add CallGraphUseCase, DuckdbCallGraphRepository,
  DuckdbFileHashRepository, OrtReranking, and CodesearchMcpServer

https://claude.ai/code/session_015EyUssCL4xezPoe2PcWEYx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP Server mode for Model Context Protocol integration (stdio and HTTP modes)
  * Support for HCL, PHP, and C++ languages
  * New CLI flags: `--format` (text/json/vimgrep), `--no-rerank`, `--verbose`
  * Cross-encoder reranking enabled by default for improved search results

* **Documentation**
  * Updated architecture overview with new capabilities
  * Added MCP server setup and usage guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->