### PR TITLE
fix: include anonymous callers in impact analysis results

### DIFF
--- a/src/application/use_cases/impact_analysis.rs
+++ b/src/application/use_cases/impact_analysis.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 use crate::application::{CallGraphQuery, CallGraphUseCase};
 use crate::domain::DomainError;
 
+pub const ANONYMOUS_SYMBOL: &str = "<anonymous>";
+
 /// A single node in the impact (blast-radius) graph.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImpactNode {
@@ -95,8 +97,17 @@ impl ImpactAnalysisUseCase {
                         // function).  Include it in the impact report so the user can see it,
                         // but don't enqueue it for further traversal – there is no named
                         // symbol to look up.
+                        let anon_key = format!(
+                            "anon:{}:{}",
+                            reference.repository_id(),
+                            reference.caller_file_path()
+                        );
+                        if visited.contains(&anon_key) {
+                            continue;
+                        }
+                        visited.insert(anon_key);
                         by_depth[next_depth - 1].push(ImpactNode {
-                            symbol: "<anonymous>".to_string(),
+                            symbol: ANONYMOUS_SYMBOL.to_string(),
                             depth: next_depth,
                             file_path: reference.caller_file_path().to_string(),
                             reference_kind: reference.reference_kind().to_string(),


### PR DESCRIPTION
When a symbol is called from top-level/module-level code (no enclosing
function), the tree-sitter parser sets caller_symbol = None. Previously
impact_analysis skipped these entirely (None => continue), so a symbol
with only anonymous callers reported zero total_affected while
symbol_context correctly showed them as <anonymous>.

Anonymous callers are now added to the impact report at the appropriate
depth. They are not enqueued for further BFS traversal since there is no
named symbol to look up.

https://claude.ai/code/session_01BtHgryU5yUXU92CBn4aPoc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved impact analysis reporting to properly handle and display anonymous callers in call chain analysis.
  * Enhanced caller traversal logic with better de-duplication to prevent redundant processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->