### PR TITLE
feat: replace LIKE-based keyword search with real BM25 via DuckDB FTS

### DIFF
--- a/tests/duckdb_vector_repository_tests.rs
+++ b/tests/duckdb_vector_repository_tests.rs
@@ -181,6 +181,7 @@ async fn duckdb_vector_repository_bm25_handles_empty_query() {
         .await
         .expect("search with empty query");
     // Empty query produces no BM25 hits; result comes from semantic leg only.
+    assert!(!results.is_empty(), "expected at least one result from semantic leg");
     assert!(results[0].score().is_finite());
 }
 


### PR DESCRIPTION
Switch the keyword search leg of the hybrid pipeline from a custom LIKE-based scoring heuristic to genuine Okapi BM25 relevance scoring using DuckDB's built-in full-text search (FTS) extension.

Key changes:
- Load `fts` extension alongside `vss` in `initialize()` and the read-only constructor.
- Add `fts_dirty: AtomicBool` to `DuckdbVectorRepository` to track whether the FTS index needs rebuilding after data mutations.
- Add `fts_schema_name()`, `fts_index_exists()`, and `rebuild_fts_index()` helpers. The index is rebuilt lazily — once per dirty window — immediately before the first BM25 query after any write. This amortises the cost over many searches rather than paying it on every `save_batch` call.
- Replace `run_text()` (LIKE patterns + custom linear scoring) with a BM25 query via `{fts_schema}.match_bm25(c.id, query)`. `stemmer=none` is used so code identifiers are matched exactly rather than stemmed.
- `save_batch()`, `delete()`, `delete_by_repository()`, and `delete_by_file_path()` all set `fts_dirty = true` after committing their transaction.
- In `search()`, a failed FTS rebuild or BM25 query degrades gracefully to semantic-only results with a `warn!` log.
- Add `duckdb_vector_repository_bm25_text_search_finds_matching_chunks` and `duckdb_vector_repository_bm25_handles_empty_query` tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * BM25 full-text search added to hybrid search with lazy index rebuilding to reduce rebuilds and improve performance.
  * Read-only flows avoid unnecessary rebuilds; writes mark the index dirty for later rebuild.
  * Improved fallback: if text search or rebuild fails, results gracefully fall back to semantic-only with a warning.

* **Bug Fixes**
  * Better handling of empty or whitespace-only text queries to avoid errors.

* **Tests**
  * Added integration tests validating BM25 text matches and empty-query behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->