### PR TITLE
fix: codesearch task spawn is always spanwn (not only on text editor …

### DIFF
--- a/ide/zed/keybindings.json
+++ b/ide/zed/keybindings.json
@@ -1,8 +1,12 @@
 [
   {
+    "bindings": {
+      "ctrl-shift-f": ["task::Spawn", { "task_name": "codesearch: search (prompt)" }]
+    }
+  },
+  {
     "context": "Editor",
     "bindings": {
-      "ctrl-shift-f": ["task::Spawn", { "task_name": "codesearch: search (prompt)" }],
       "ctrl-shift-i": ["task::Spawn", { "task_name": "codesearch: impact analysis" }],
       "ctrl-shift-x": ["task::Spawn", { "task_name": "codesearch: symbol context" }]
     }


### PR DESCRIPTION
…focus)