### PR TITLE
fix: scip indexing with js

### DIFF
--- a/src/connector/adapter/scip/indexer.rs
+++ b/src/connector/adapter/scip/indexer.rs
@@ -38,6 +38,7 @@ impl IndexerKind {
         match self {
             IndexerKind::TypeScript => vec![
                 "index".to_string(),
+                "--infer-tsconfig".to_string(),
                 "--output".to_string(),
                 output_path.to_string_lossy().to_string(),
             ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Language detection now infers file types from extensions when explicit language information is unavailable.
  * TypeScript indexer enhanced with tsconfig inference support.

* **Improvements**
  * Optimized reference and hash persistence for unchanged files during indexing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->