### PR TITLE
fix: context and impact command output documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,16 +163,13 @@ codesearch impact authenticate --format json
 ```
 Impact analysis for 'authenticate'
 ─────────────────────────────────────────
-Total affected symbols : 4
-Max depth reached      : 2
+process_request [call]  src/router.rs:10
+└── handle_login [call]  src/api/auth.rs:42
+    └── authenticate
 
-Depth 1 (2 symbol(s)):
-  • handle_login [call]  src/api/auth.rs
-  • verify_token [call]  src/middleware/auth.rs
-
-Depth 2 (2 symbol(s)):
-  • process_request [call]  src/router.rs
-  • run_tests [call]  tests/integration.rs
+run_tests [call]  tests/integration.rs:5
+└── verify_token [call]  src/middleware/auth.rs:18
+    └── authenticate
 ```
 
 ### Symbol Context
@@ -197,7 +194,6 @@ codesearch context authenticate --format json
 ```
 Context for 'authenticate'
 ─────────────────────────────────────────
-
 Callers (2 total) — who uses this symbol:
   ← handle_login [call]  src/api/auth.rs:42
   ← verify_session [call]  src/middleware/session.rs:18

--- a/docs/features/call-graph.md
+++ b/docs/features/call-graph.md
@@ -56,16 +56,13 @@ codesearch impact authenticate --format json
 ```
 Impact analysis for 'authenticate'
 ─────────────────────────────────────────
-Total affected symbols : 4
-Max depth reached      : 2
+process_request [call]  src/router.rs:10
+└── handle_login [call]  src/api/auth.rs:42
+    └── authenticate
 
-Depth 1 (2 symbol(s)):
-  • handle_login [call]  src/api/auth.rs
-  • verify_token [call]  src/middleware/auth.rs
-
-Depth 2 (2 symbol(s)):
-  • process_request [call]  src/router.rs
-  • run_tests [call]  tests/integration.rs
+run_tests [call]  tests/integration.rs:5
+└── verify_token [call]  src/middleware/auth.rs:18
+    └── authenticate
 ```
 
 ### JSON Schema
@@ -118,7 +115,6 @@ codesearch context authenticate --format json
 ```
 Context for 'authenticate'
 ─────────────────────────────────────────
-
 Callers (2 total) — who uses this symbol:
   ← handle_login [call]  src/api/auth.rs:42
   ← verify_session [call]  src/middleware/session.rs:18


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated call graph feature examples and output format references.
  * Added short-form CLI flag options to command documentation.
  * Refreshed example outputs to match current call path visualization display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->