### PR TITLE
fix: update default LM Studio model from ministral-3b to qwen3.5-4b

### DIFF
--- a/docs/features/embedding-backends.md
+++ b/docs/features/embedding-backends.md
@@ -61,7 +61,7 @@ All API-target traffic shares the same environment variables used by query expan
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `ANTHROPIC_BASE_URL` | `http://localhost:1234` | Base URL for embeddings (`/v1/embeddings`) and reranking (`/v1/messages`) |
-| `ANTHROPIC_MODEL` | `mistralai/ministral-3-3b` | Chat model used for reranking |
+| `ANTHROPIC_MODEL` | `qwen/qwen3.5-4b` | Chat model used for reranking |
 | `ANTHROPIC_API_KEY` | `""` | API key — not required for local servers |
 
 > LM Studio exposes both `/v1/embeddings` (OpenAI-compatible) and `/v1/messages` (Anthropic-compatible) on the same port, so one `ANTHROPIC_BASE_URL` covers everything.

--- a/src/connector/adapter/anthropic_client.rs
+++ b/src/connector/adapter/anthropic_client.rs
@@ -12,7 +12,7 @@ pub const DEFAULT_BASE_URL: &str = "http://localhost:1234";
 const MESSAGES_PATH: &str = "/v1/messages";
 const ANTHROPIC_API_VERSION: &str = "2023-06-01";
 /// Default model matches the LM Studio local-first default.
-const DEFAULT_MODEL: &str = "mistralai/ministral-3-3b";
+const DEFAULT_MODEL: &str = "qwen/qwen3.5-4b";
 const MAX_TOKENS: u32 = 256;
 
 #[derive(Serialize)]
@@ -104,7 +104,7 @@ impl AnthropicClient {
     /// | Variable             | Default                   | Purpose                   |
     /// |----------------------|---------------------------|---------------------------|
     /// | `ANTHROPIC_BASE_URL` | `http://localhost:1234`   | LM Studio / any server    |
-    /// | `ANTHROPIC_MODEL`    | `mistralai/ministral-3-3b` | Model in LM Studio       |
+    /// | `ANTHROPIC_MODEL`    | `qwen/qwen3.5-4b`          | Model in LM Studio       |
     /// | `ANTHROPIC_API_KEY`  | `""` (empty)              | Not required for local    |
     pub fn from_env() -> Self {
         let base =

--- a/src/connector/adapter/anthropic_reranking.rs
+++ b/src/connector/adapter/anthropic_reranking.rs
@@ -39,7 +39,7 @@ Example output: [0.97, 0.02]";
 /// | Variable             | Default                    |
 /// |----------------------|----------------------------|
 /// | `ANTHROPIC_BASE_URL` | `http://localhost:1234`    |
-/// | `ANTHROPIC_MODEL`    | `mistralai/ministral-3-3b` |
+/// | `ANTHROPIC_MODEL`    | `qwen/qwen3.5-4b`          |
 /// | `ANTHROPIC_API_KEY`  | `""` (not required locally)|
 pub struct AnthropicReranking {
     client: Arc<dyn ChatClient>,

--- a/src/connector/adapter/lm_studio_reranking.rs
+++ b/src/connector/adapter/lm_studio_reranking.rs
@@ -39,7 +39,7 @@ Example output: [0.97, 0.02]";
 /// | Variable             | Default                    |
 /// |----------------------|----------------------------|
 /// | `ANTHROPIC_BASE_URL` | `http://localhost:1234`    |
-/// | `ANTHROPIC_MODEL`    | `mistralai/ministral-3-3b` |
+/// | `ANTHROPIC_MODEL`    | `qwen/qwen3.5-4b`          |
 /// | `ANTHROPIC_API_KEY`  | `""` (not required locally)|
 pub struct LmStudioReranking {
     client: Arc<dyn ChatClient>,


### PR DESCRIPTION
https://claude.ai/code/session_01WmJo6QyjHsyjW7vBa4z9pu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default embedding model configuration from Mistral to Qwen. This change affects the reranking behavior used by the system. Documentation and configuration defaults have been aligned to reflect the new model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->