### PR TITLE
feat: replace Zed FZF integration with TUI

### DIFF
--- a/ide/zed/keybindings.json
+++ b/ide/zed/keybindings.json
@@ -1,14 +1,14 @@
 [
   {
     "bindings": {
-      "ctrl-shift-f": ["task::Spawn", { "task_name": "codesearch: search", "reveal_target": "center" }]
+      "ctrl-shift-f": ["task::Spawn", { "task_name": "codesearch: tui", "reveal_target": "center" }]
     }
   },
   {
     "context": "Editor",
     "bindings": {
-      "ctrl-shift-i": ["task::Spawn", { "task_name": "codesearch: impact analysis", "reveal_target": "center" }],
-      "ctrl-shift-x": ["task::Spawn", { "task_name": "codesearch: symbol context", "reveal_target": "center" }]
+      "ctrl-shift-i": ["task::Spawn", { "task_name": "codesearch: tui impact", "reveal_target": "center" }],
+      "ctrl-shift-x": ["task::Spawn", { "task_name": "codesearch: tui impact", "reveal_target": "center" }]
     }
   }
 ]

--- a/ide/zed/tasks.json
+++ b/ide/zed/tasks.json
@@ -1,27 +1,19 @@
 [
   {
-    "label": "codesearch: search",
-    "command": "bash -c 'printf \"Semantic search: \"; read -r q; [[ -z \"$q\" ]] && exit 0; if command -v bat &>/dev/null; then p=\"bat --color=always --style=numbers --highlight-line {2} -- {1} 2>/dev/null\"; else p=\"cat -n -- {1} 2>/dev/null\"; fi; r=$(codesearch search \"$q\" --format vimgrep 2>/dev/null | fzf --ansi --delimiter : --prompt \"codesearch> \" --header \"Query: $q  ·  Enter to open  ·  Ctrl-C to quit\" --layout reverse --preview \"$p\" --preview-window \"right,60%,border-left,+{2}+3/3,~3\"); [[ -n \"$r\" ]] || exit 0; file=$(echo \"$r\" | cut -d: -f1); line=$(echo \"$r\" | cut -d: -f2); zed \"$file:$line\"'",
+    "label": "codesearch: tui",
+    "command": "codesearch tui",
     "tags": ["codesearch"],
     "hide": "always",
-    "use_new_terminal": true,
-    "allow_concurrent_runs": true
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false
   },
   {
-    "label": "codesearch: symbol context",
-    "command": "bash -c 'if command -v bat &>/dev/null; then p=\"bat --color=always --style=numbers --highlight-line {2} -- {1} 2>/dev/null\"; else p=\"cat -n -- {1} 2>/dev/null\"; fi; r=$(codesearch context \"$ZED_SYMBOL\" --format vimgrep 2>/dev/null | fzf --ansi --delimiter : --prompt \"context> \" --header \"Symbol: $ZED_SYMBOL  ·  Enter to open  ·  Ctrl-C to quit\" --layout reverse --preview \"$p\" --preview-window \"right,60%,border-left,+{2}+3/3,~3\"); [[ -n \"$r\" ]] || exit 0; file=$(echo \"$r\" | cut -d: -f1); line=$(echo \"$r\" | cut -d: -f2); zed \"$file:$line\"'",
+    "label": "codesearch: tui impact",
+    "command": "codesearch tui --mode impact --query \"$ZED_SYMBOL\"",
     "tags": ["codesearch"],
     "hide": "always",
-    "use_new_terminal": true,
-    "allow_concurrent_runs": true
-  },
-  {
-    "label": "codesearch: impact analysis",
-    "command": "bash -c 'if command -v bat &>/dev/null; then p=\"bat --color=always --style=numbers --highlight-line {2} -- {1} 2>/dev/null\"; else p=\"cat -n -- {1} 2>/dev/null\"; fi; r=$(codesearch impact \"$ZED_SYMBOL\" --format vimgrep 2>/dev/null | fzf --ansi --delimiter : --prompt \"impact> \" --header \"Impact: $ZED_SYMBOL  ·  Enter to open  ·  Ctrl-C to quit\" --layout reverse --preview \"$p\" --preview-window \"right,60%,border-left,+{2}+3/3,~3\"); [[ -n \"$r\" ]] || exit 0; file=$(echo \"$r\" | cut -d: -f1); line=$(echo \"$r\" | cut -d: -f2); zed \"$file:$line\"'",
-    "tags": ["codesearch"],
-    "hide": "always",
-    "use_new_terminal": true,
-    "allow_concurrent_runs": true
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false
   },
   {
     "label": "codesearch: index current directory",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -12,6 +12,16 @@ pub enum OutputFormat {
     Vimgrep,
 }
 
+/// Initial mode for the interactive TUI.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
+pub enum TuiMode {
+    /// Open in search mode (default).
+    #[default]
+    Search,
+    /// Open in impact analysis mode.
+    Impact,
+}
+
 /// Embedding backend to use for indexing and search.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
 pub enum EmbeddingTarget {
@@ -169,5 +179,13 @@ pub enum Commands {
         /// Restrict all queries to a specific repository ID
         #[arg(short, long)]
         repository: Option<String>,
+
+        /// Pre-populate the input box with this query and immediately dispatch it.
+        #[arg(long)]
+        query: Option<String>,
+
+        /// Which mode to open the TUI in: 'search' (default) or 'impact'.
+        #[arg(long, value_enum, default_value = "search")]
+        mode: TuiMode,
     },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub use application::{
     VectorRepository,
 };
 
-pub use cli::{Commands, EmbeddingTarget, LlmTarget, OutputFormat, RerankingTarget};
+pub use cli::{Commands, EmbeddingTarget, LlmTarget, OutputFormat, RerankingTarget, TuiMode};
 
 pub use connector::{
     AnthropicClient, AnthropicReranking, DuckdbCallGraphRepository,

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,13 +204,15 @@ async fn main() -> Result<()> {
     let container = Container::new(config).await?;
 
     // Handle TUI command specially — it takes over the terminal for its lifetime.
-    if let Commands::Tui { repository } = cli.command {
+    if let Commands::Tui { repository, query, mode } = cli.command {
         use codesearch::tui::TuiApp;
         let app = TuiApp::new(
             Arc::new(container.search_use_case()),
             Arc::new(container.impact_use_case()),
             Arc::new(container.snippet_lookup_use_case()),
             repository,
+            mode,
+            query,
         );
         return app.run().await;
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -12,6 +12,7 @@ use crate::domain::SearchQuery;
 use super::cache::TuiCache;
 use super::event::TuiEvent;
 use super::state::{ActiveMode, AppState, ImpactPane, SearchPane};
+use crate::cli::TuiMode;
 use super::views;
 
 const SEARCH_LIMIT: usize = 20;
@@ -34,10 +35,16 @@ impl TuiApp {
         impact_uc: Arc<ImpactAnalysisUseCase>,
         snippet_uc: Arc<SnippetLookupUseCase>,
         repository: Option<String>,
+        mode: TuiMode,
+        query: Option<String>,
     ) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
+        let initial_mode = match mode {
+            TuiMode::Search => ActiveMode::Search,
+            TuiMode::Impact => ActiveMode::Impact,
+        };
         Self {
-            state: AppState::new(repository),
+            state: AppState::new(repository, initial_mode, query),
             cache: TuiCache::default(),
             search_uc,
             impact_uc,
@@ -49,6 +56,16 @@ impl TuiApp {
     }
 
     pub async fn run(mut self) -> Result<()> {
+        // Auto-dispatch the initial query if one was provided via CLI.
+        match self.state.mode {
+            ActiveMode::Search if !self.state.search.input.is_empty() => {
+                self.dispatch_search();
+            }
+            ActiveMode::Impact if !self.state.impact.input.is_empty() => {
+                self.dispatch_impact();
+            }
+            _ => {}
+        }
         let mut terminal = ratatui::init();
         let result = self.run_loop(&mut terminal).await;
         ratatui::restore();

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -90,9 +90,13 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(repository: Option<String>) -> Self {
-        Self {
-            mode: ActiveMode::Search,
+    pub fn new(
+        repository: Option<String>,
+        initial_mode: ActiveMode,
+        initial_query: Option<String>,
+    ) -> Self {
+        let mut state = Self {
+            mode: initial_mode.clone(),
             search: SearchState {
                 repository: repository.clone(),
                 ..Default::default()
@@ -102,7 +106,20 @@ impl AppState {
                 ..Default::default()
             },
             should_quit: false,
+        };
+        if let Some(query) = initial_query {
+            match initial_mode {
+                ActiveMode::Search => {
+                    state.search.cursor = query.chars().count();
+                    state.search.input = query;
+                }
+                ActiveMode::Impact => {
+                    state.impact.cursor = query.chars().count();
+                    state.impact.input = query;
+                }
+            }
         }
+        state
     }
 
     /// The text currently typed in the active mode's input box.


### PR DESCRIPTION
## Summary

- Replaces the three FZF-based Zed tasks (`codesearch: search`, `codesearch: symbol context`, `codesearch: impact analysis`) with two TUI tasks (`codesearch: tui` and `codesearch: tui impact`)
- Both tasks use `use_new_terminal: false` and `allow_concurrent_runs: false` so Zed maintains a single shared terminal pane that is reused or reopened if closed
- Adds `--mode` (`search` | `impact`) and `--query` CLI flags to `codesearch tui` — when triggered from the editor (e.g. `ctrl-shift-i` with a symbol selected), the TUI opens directly in impact mode with the symbol pre-populated and the analysis auto-dispatched

## Test plan

- [ ] `ctrl-shift-f` opens the TUI in search mode in a reusable pane
- [ ] `ctrl-shift-i` / `ctrl-shift-x` with a symbol selected opens the TUI in impact mode with the symbol pre-loaded and analysis running
- [ ] Triggering a keybind when the TUI pane is already open does not spawn a second instance
- [ ] Triggering a keybind after closing the TUI pane reopens it in the same slot
- [ ] `codesearch tui --mode impact --query "SomeSymbol"` starts in impact mode with the analysis dispatched immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TUI now accepts pre-populated search queries and mode selection via command-line arguments, allowing direct initialization of the search interface
  * Updated keyboard shortcuts for code search operations (ctrl-shift-f, ctrl-shift-i, ctrl-shift-x)

* **Chores**
  * Streamlined task configuration for code search functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->