### PR TITLE
feat: add execution features with criticality scoring

### DIFF
--- a/src/application/use_cases/execution_features.rs
+++ b/src/application/use_cases/execution_features.rs
@@ -1,52 +1,26 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 
 use crate::application::{CallGraphQuery, CallGraphUseCase};
 use crate::domain::{DomainError, ExecutionFeature, FeatureNode};
 
 // ──────────────────────────────────────────────────────────────────────────────
-// Entry-point detection constants
-// ──────────────────────────────────────────────────────────────────────────────
-
-/// Exact short names that are always treated as entry points.
-const ENTRY_POINT_EXACT: &[&str] = &[
-    "main", "run", "start", "init", "handle", "execute", "process",
-];
-
-/// Prefixes that mark a symbol as an entry point (e.g. test functions).
-const ENTRY_POINT_PREFIXES: &[&str] = &["test_", "it_", "handle_", "on_"];
-
-// ──────────────────────────────────────────────────────────────────────────────
 // Criticality scoring constants (weights must sum to 1.0)
 // ──────────────────────────────────────────────────────────────────────────────
 
-const WEIGHT_FILE_SPREAD: f32 = 0.30;
-const WEIGHT_SECURITY: f32 = 0.25;
-const WEIGHT_EXTERNAL_CALLS: f32 = 0.20;
-const WEIGHT_TEST_COVERAGE_GAP: f32 = 0.15;
-const WEIGHT_DEPTH: f32 = 0.10;
+const WEIGHT_FILE_SPREAD: f32 = 0.35;
+const WEIGHT_EXTERNAL_CALLS: f32 = 0.25;
+const WEIGHT_TEST_COVERAGE_GAP: f32 = 0.25;
+const WEIGHT_DEPTH: f32 = 0.15;
 
 /// Soft reference depth for depth-score normalisation. A path reaching this
 /// depth scores 1.0 on the depth signal; deeper paths are clamped to 1.0.
 const DEPTH_REFERENCE: f32 = 20.0;
 
-/// Score assigned when no test symbol is reachable from the entry point's
-/// callers (no test coverage gap detected).
+/// Score assigned when no test symbol directly calls the entry point.
 const TEST_COVERAGE_GAP_SCORE: f32 = 0.30;
-/// Score assigned when test coverage IS present.
+/// Score assigned when a test caller IS present.
 const TEST_COVERAGE_PRESENT_SCORE: f32 = 0.05;
-
-/// Security-sensitive keywords. If any node's symbol contains one of these
-/// substrings (case-insensitive) the security signal fires at full strength.
-const SECURITY_KEYWORDS: &[&str] = &[
-    "auth",
-    "crypto",
-    "validate",
-    "password",
-    "token",
-    "secret",
-    "permission",
-];
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Use case
@@ -138,12 +112,11 @@ impl ExecutionFeaturesUseCase {
             }
         };
 
-        // Verify the resolved symbol is actually an entry point. A symbol
-        // qualifies when its short name matches a known pattern or nothing in
+        // Verify the resolved symbol is actually an entry point: nothing within
         // the same repository calls it.
         let repo_query = CallGraphQuery::new().with_repository(&effective_repo);
         let callers_in_repo = self.call_graph.find_callers(&fqn, &repo_query).await?;
-        if !callers_in_repo.is_empty() && !short_name_is_entry_point(&fqn) {
+        if !callers_in_repo.is_empty() {
             return Ok(None);
         }
 
@@ -205,41 +178,26 @@ impl ExecutionFeaturesUseCase {
     // ──────────────────────────────────────────────────────────────────────────
 
     /// Return the set of fully-qualified symbols in `repository_id` that are
-    /// entry points (zero callers, or matching a well-known name pattern).
+    /// entry points: symbols that call at least one other symbol but are
+    /// themselves never called within the repository.
     async fn find_entry_points(&self, repository_id: &str) -> Result<Vec<String>, DomainError> {
         let all_refs = self.call_graph.find_by_repository(repository_id).await?;
 
-        // Collect every symbol that appears as a caller and every symbol that
-        // appears as a callee.
         let mut callee_symbols: HashSet<String> = HashSet::new();
         let mut caller_symbols: HashSet<String> = HashSet::new();
-
-        // Also track location information for each caller symbol (first seen).
-        let mut caller_file: HashMap<String, String> = HashMap::new();
 
         for r in &all_refs {
             callee_symbols.insert(r.callee_symbol().to_string());
             if let Some(caller) = r.caller_symbol() {
-                let caller = caller.to_string();
-                caller_file
-                    .entry(caller.clone())
-                    .or_insert_with(|| r.caller_file_path().to_string());
-                caller_symbols.insert(caller);
+                caller_symbols.insert(caller.to_string());
             }
         }
 
-        // A symbol is an entry point when it:
-        //   (a) appears as a caller (it calls something) AND
-        //   (b) does NOT appear as a callee (nothing calls it),
-        //       OR its short name matches a well-known entry-point pattern.
+        // Entry point = calls something (has outgoing edges) AND is never called
+        // (has no incoming edges within this repository).
         let mut entry_points: Vec<String> = caller_symbols
-            .iter()
-            .filter(|sym| {
-                let not_called = !callee_symbols.contains(*sym);
-                let name_match = short_name_is_entry_point(sym);
-                not_called || name_match
-            })
-            .cloned()
+            .into_iter()
+            .filter(|sym| !callee_symbols.contains(sym))
             .collect();
 
         entry_points.sort();
@@ -352,21 +310,15 @@ impl ExecutionFeaturesUseCase {
         let file_count = distinct_files.len();
         let feature_depth = path.iter().map(|n| n.depth).max().unwrap_or(0);
 
-        // Signal 1 — file spread
+        // Signal 1 — file spread: ratio of distinct files to total path nodes.
         let file_spread_score = (file_count as f32 / total_nodes as f32).min(1.0);
 
-        // Signal 2 — security sensitivity
-        let security_score = if path.iter().any(|n| is_security_sensitive(&n.symbol)) {
-            1.0_f32
-        } else {
-            0.0_f32
-        };
-
-        // Signal 3 — external calls
+        // Signal 2 — external calls: ratio of leaf nodes (no outgoing edges in
+        // this repo) to all callee references seen during BFS.
         let external_score = (unresolved_callees as f32 / total_callees_seen as f32).min(1.0);
 
-        // Signal 4 — test coverage gap
-        // Check whether any test symbol is a direct or indirect caller of the entry point.
+        // Signal 3 — test coverage gap: high when nothing directly calls the
+        // entry point with a test_ / it_ prefix.
         let callers_query = CallGraphQuery::new().with_repository(repository_id);
         let callers_of_entry = self
             .call_graph
@@ -383,11 +335,10 @@ impl ExecutionFeaturesUseCase {
             TEST_COVERAGE_GAP_SCORE
         };
 
-        // Signal 5 — depth
+        // Signal 4 — depth: normalised call-chain length.
         let depth_score = (feature_depth as f32 / DEPTH_REFERENCE).min(1.0);
 
         let criticality = (WEIGHT_FILE_SPREAD * file_spread_score
-            + WEIGHT_SECURITY * security_score
             + WEIGHT_EXTERNAL_CALLS * external_score
             + WEIGHT_TEST_COVERAGE_GAP * test_gap_score
             + WEIGHT_DEPTH * depth_score)
@@ -429,28 +380,9 @@ fn short_name(fqn: &str) -> String {
     base.trim().to_string()
 }
 
-/// Return `true` when the short name of `fqn` matches a well-known entry-point
-/// pattern (exact names or prefixes).
-fn short_name_is_entry_point(fqn: &str) -> bool {
-    let sn = short_name(fqn);
-    let sn_lower = sn.to_lowercase();
-    if ENTRY_POINT_EXACT.iter().any(|&e| sn_lower == e) {
-        return true;
-    }
-    ENTRY_POINT_PREFIXES
-        .iter()
-        .any(|&p| sn_lower.starts_with(p))
-}
-
 /// Return `true` when a symbol looks like a test function.
 fn is_test_symbol(symbol: &str) -> bool {
     let sn = short_name(symbol);
     let sn_lower = sn.to_lowercase();
     sn_lower.starts_with("test_") || sn_lower.starts_with("it_")
-}
-
-/// Return `true` when a symbol contains a security-sensitive keyword.
-fn is_security_sensitive(symbol: &str) -> bool {
-    let lower = symbol.to_lowercase();
-    SECURITY_KEYWORDS.iter().any(|&kw| lower.contains(kw))
 }

--- a/src/application/use_cases/execution_features.rs
+++ b/src/application/use_cases/execution_features.rs
@@ -298,11 +298,6 @@ impl ExecutionFeaturesUseCase {
             .filter(|n| !symbols_with_callees.contains(&n.symbol))
             .count();
 
-        // Avoid division by zero in the external_score calculation below.
-        if total_callees_seen == 0 {
-            total_callees_seen = 1;
-        }
-
         // ── Criticality scoring ────────────────────────────────────────────
         let total_nodes = path.len().max(1);
         let distinct_files: HashSet<&str> = path.iter().map(|n| n.file_path.as_str()).collect();
@@ -314,7 +309,8 @@ impl ExecutionFeaturesUseCase {
 
         // Signal 2 — external calls: ratio of leaf nodes (no outgoing edges in
         // this repo) to all callee references seen during BFS.
-        let external_score = (unresolved_callees as f32 / total_callees_seen as f32).min(1.0);
+        let external_score =
+            (unresolved_callees as f32 / total_callees_seen.max(1) as f32).min(1.0);
 
         // Signal 3 — test coverage gap. Entry points have no callers in the
         // repository by definition, so the gap score applies unconditionally.

--- a/src/application/use_cases/execution_features.rs
+++ b/src/application/use_cases/execution_features.rs
@@ -111,10 +111,43 @@ impl ExecutionFeaturesUseCase {
             return Ok(None);
         }
 
-        // Use the first resolved symbol as the entry point.
-        let fqn = &resolved[0];
-        let repo = repository_id.unwrap_or("");
-        let feature = self.build_feature(fqn, repo).await?;
+        let fqn = resolved[0].clone();
+
+        // Determine the effective repository, either from the caller-supplied
+        // hint or by discovering it from the resolved symbol's call-graph edges.
+        let effective_repo: String = if let Some(repo) = repository_id {
+            repo.to_string()
+        } else {
+            let discovery_query = CallGraphQuery::new();
+            // Check outgoing edges first; entry points typically have them.
+            let callees = self
+                .call_graph
+                .find_callees(&fqn, &discovery_query)
+                .await?;
+            if let Some(r) = callees.first() {
+                r.repository_id().to_string()
+            } else {
+                let callers = self
+                    .call_graph
+                    .find_callers(&fqn, &discovery_query)
+                    .await?;
+                callers
+                    .first()
+                    .map(|r| r.repository_id().to_string())
+                    .unwrap_or_default()
+            }
+        };
+
+        // Verify the resolved symbol is actually an entry point. A symbol
+        // qualifies when its short name matches a known pattern or nothing in
+        // the same repository calls it.
+        let repo_query = CallGraphQuery::new().with_repository(&effective_repo);
+        let callers_in_repo = self.call_graph.find_callers(&fqn, &repo_query).await?;
+        if !callers_in_repo.is_empty() && !short_name_is_entry_point(&fqn) {
+            return Ok(None);
+        }
+
+        let feature = self.build_feature(&fqn, &effective_repo).await?;
         Ok(Some(feature))
     }
 
@@ -229,13 +262,47 @@ impl ExecutionFeaturesUseCase {
         // ── Forward BFS ────────────────────────────────────────────────────
         let mut visited: HashSet<String> = HashSet::new();
         let mut queue: VecDeque<(String, usize, String, u32)> = VecDeque::new();
+        let mut path: Vec<FeatureNode> = Vec::new();
+        // Symbols that have at least one outgoing edge in this repo.
+        // Non-root nodes absent from this set are BFS leaves (unresolved / external).
+        let mut symbols_with_callees: HashSet<String> = HashSet::new();
+        let mut total_callees_seen: usize = 0;
 
         visited.insert(entry_point.to_string());
-        queue.push_back((entry_point.to_string(), 0, String::new(), 0));
 
-        let mut path: Vec<FeatureNode> = Vec::new();
-        let mut unresolved_callees: usize = 0;
-        let mut total_callees_seen: usize = 0;
+        // Pre-fetch the entry-point's callees to (a) resolve its own file path
+        // so the root node is not seeded with an empty string, and (b) avoid a
+        // redundant call_graph lookup on the first BFS iteration.
+        let initial_callees = self.call_graph.find_callees(entry_point, &query).await?;
+        let entry_file_path = initial_callees
+            .first()
+            .map(|r| r.caller_file_path().to_string())
+            .unwrap_or_default();
+
+        path.push(FeatureNode {
+            symbol: entry_point.to_string(),
+            file_path: entry_file_path,
+            line: 0,
+            depth: 0,
+            repository_id: repository_id.to_string(),
+        });
+
+        if !initial_callees.is_empty() {
+            symbols_with_callees.insert(entry_point.to_string());
+        }
+        for reference in &initial_callees {
+            total_callees_seen += 1;
+            let callee = reference.callee_symbol().to_string();
+            if !visited.contains(&callee) {
+                visited.insert(callee.clone());
+                queue.push_back((
+                    callee,
+                    1,
+                    reference.reference_file_path().to_string(),
+                    reference.reference_line(),
+                ));
+            }
+        }
 
         while let Some((current, depth, file_path, line)) = queue.pop_front() {
             path.push(FeatureNode {
@@ -247,6 +314,9 @@ impl ExecutionFeaturesUseCase {
             });
 
             let callees = self.call_graph.find_callees(&current, &query).await?;
+            if !callees.is_empty() {
+                symbols_with_callees.insert(current.clone());
+            }
             for reference in &callees {
                 total_callees_seen += 1;
                 let callee = reference.callee_symbol().to_string();
@@ -254,12 +324,6 @@ impl ExecutionFeaturesUseCase {
                     continue;
                 }
                 visited.insert(callee.clone());
-
-                // A callee is considered "external" (unresolved) when it does
-                // not appear as a caller_symbol anywhere in this repository's
-                // call graph — i.e. we have no outgoing edges for it.
-                // We approximate this by checking whether we've seen it as a
-                // caller; the check is done lazily after the BFS.
                 queue.push_back((
                     callee,
                     depth + 1,
@@ -269,17 +333,15 @@ impl ExecutionFeaturesUseCase {
             }
         }
 
-        // Count unresolved callees: leaf nodes in the forward BFS (excluding the
-        // entry point) that produced no further callees — a proxy for external or
-        // stdlib calls that we could not trace further.
-        for node in path.iter().skip(1) {
-            // leaf nodes that the BFS couldn't expand
-            let has_callees_in_path = path.iter().any(|n| n.depth == node.depth + 1);
-            if !has_callees_in_path && node.depth == path.iter().map(|n| n.depth).max().unwrap_or(0) {
-                unresolved_callees += 1;
-            }
-        }
-        // Fallback: if total_callees_seen is 0 avoid division by zero.
+        // Unresolved callees: non-root nodes with no outgoing edges in this
+        // repository — a proxy for external / stdlib calls we cannot trace.
+        let unresolved_callees = path
+            .iter()
+            .skip(1)
+            .filter(|n| !symbols_with_callees.contains(&n.symbol))
+            .count();
+
+        // Avoid division by zero in the external_score calculation below.
         if total_callees_seen == 0 {
             total_callees_seen = 1;
         }
@@ -309,8 +371,7 @@ impl ExecutionFeaturesUseCase {
         let callers_of_entry = self
             .call_graph
             .find_callers(entry_point, &callers_query)
-            .await
-            .unwrap_or_default();
+            .await?;
         let has_test_caller = callers_of_entry.iter().any(|r| {
             r.caller_symbol()
                 .map(|s| is_test_symbol(s))

--- a/src/application/use_cases/execution_features.rs
+++ b/src/application/use_cases/execution_features.rs
@@ -1,0 +1,395 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Arc;
+
+use crate::application::{CallGraphQuery, CallGraphUseCase};
+use crate::domain::{DomainError, ExecutionFeature, FeatureNode};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Entry-point detection constants
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Exact short names that are always treated as entry points.
+const ENTRY_POINT_EXACT: &[&str] = &[
+    "main", "run", "start", "init", "handle", "execute", "process",
+];
+
+/// Prefixes that mark a symbol as an entry point (e.g. test functions).
+const ENTRY_POINT_PREFIXES: &[&str] = &["test_", "it_", "handle_", "on_"];
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Criticality scoring constants (weights must sum to 1.0)
+// ──────────────────────────────────────────────────────────────────────────────
+
+const WEIGHT_FILE_SPREAD: f32 = 0.30;
+const WEIGHT_SECURITY: f32 = 0.25;
+const WEIGHT_EXTERNAL_CALLS: f32 = 0.20;
+const WEIGHT_TEST_COVERAGE_GAP: f32 = 0.15;
+const WEIGHT_DEPTH: f32 = 0.10;
+
+/// Soft reference depth for depth-score normalisation. A path reaching this
+/// depth scores 1.0 on the depth signal; deeper paths are clamped to 1.0.
+const DEPTH_REFERENCE: f32 = 20.0;
+
+/// Score assigned when no test symbol is reachable from the entry point's
+/// callers (no test coverage gap detected).
+const TEST_COVERAGE_GAP_SCORE: f32 = 0.30;
+/// Score assigned when test coverage IS present.
+const TEST_COVERAGE_PRESENT_SCORE: f32 = 0.05;
+
+/// Security-sensitive keywords. If any node's symbol contains one of these
+/// substrings (case-insensitive) the security signal fires at full strength.
+const SECURITY_KEYWORDS: &[&str] = &[
+    "auth",
+    "crypto",
+    "validate",
+    "password",
+    "token",
+    "secret",
+    "permission",
+];
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Use case
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Use case that discovers execution features — named forward call chains
+/// rooted at entry-point symbols — and scores each one for criticality.
+pub struct ExecutionFeaturesUseCase {
+    call_graph: Arc<CallGraphUseCase>,
+}
+
+impl ExecutionFeaturesUseCase {
+    pub fn new(call_graph: Arc<CallGraphUseCase>) -> Self {
+        Self { call_graph }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Public API
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// Detect all entry points for `repository_id` and compute their features,
+    /// returning up to `limit` results sorted by descending criticality.
+    pub async fn list_features(
+        &self,
+        repository_id: &str,
+        limit: usize,
+    ) -> Result<Vec<ExecutionFeature>, DomainError> {
+        let entry_points = self.find_entry_points(repository_id).await?;
+        let mut features = Vec::with_capacity(entry_points.len().min(limit));
+
+        for ep in entry_points {
+            let feature = self.build_feature(&ep, repository_id).await?;
+            features.push(feature);
+        }
+
+        features.sort_by(|a, b| b.criticality.partial_cmp(&a.criticality).unwrap_or(std::cmp::Ordering::Equal));
+        features.truncate(limit);
+        Ok(features)
+    }
+
+    /// Retrieve a single feature by entry-point symbol name (exact or substring).
+    ///
+    /// Returns `None` when the symbol cannot be found in the call graph or is
+    /// not an entry point.
+    pub async fn get_feature(
+        &self,
+        symbol: &str,
+        repository_id: Option<&str>,
+    ) -> Result<Option<ExecutionFeature>, DomainError> {
+        let mut query = CallGraphQuery::new();
+        if let Some(repo) = repository_id {
+            query = query.with_repository(repo);
+        }
+
+        // Resolve the symbol to a fully-qualified name.
+        let resolved = self
+            .call_graph
+            .resolve_symbols(symbol, &query, 10)
+            .await?;
+
+        if resolved.is_empty() {
+            return Ok(None);
+        }
+
+        // Use the first resolved symbol as the entry point.
+        let fqn = &resolved[0];
+        let repo = repository_id.unwrap_or("");
+        let feature = self.build_feature(fqn, repo).await?;
+        Ok(Some(feature))
+    }
+
+    /// Given a set of changed symbols, return every feature whose call chain
+    /// includes at least one of them, sorted by descending criticality.
+    pub async fn get_affected_features(
+        &self,
+        changed_symbols: &[String],
+        repository_id: Option<&str>,
+    ) -> Result<Vec<ExecutionFeature>, DomainError> {
+        if changed_symbols.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let changed_set: HashSet<&str> = changed_symbols.iter().map(String::as_str).collect();
+
+        // Determine which repositories to scan.
+        let repo_ids: Vec<String> = if let Some(repo) = repository_id {
+            vec![repo.to_string()]
+        } else {
+            // Collect every repository that any of the changed symbols appears in.
+            let mut repos: HashSet<String> = HashSet::new();
+            for sym in changed_symbols {
+                let query = CallGraphQuery::new();
+                let callers = self.call_graph.find_callers(sym, &query).await?;
+                for r in &callers {
+                    repos.insert(r.repository_id().to_string());
+                }
+                let callees = self.call_graph.find_callees(sym, &query).await?;
+                for r in &callees {
+                    repos.insert(r.repository_id().to_string());
+                }
+            }
+            repos.into_iter().collect()
+        };
+
+        let mut affected: Vec<ExecutionFeature> = Vec::new();
+        for repo in &repo_ids {
+            let features = self.list_features(repo, usize::MAX).await?;
+            for feature in features {
+                let symbols_in_path: HashSet<&str> =
+                    feature.path.iter().map(|n| n.symbol.as_str()).collect();
+                if changed_set.iter().any(|s| symbols_in_path.contains(*s)) {
+                    affected.push(feature);
+                }
+            }
+        }
+
+        affected.sort_by(|a, b| b.criticality.partial_cmp(&a.criticality).unwrap_or(std::cmp::Ordering::Equal));
+        Ok(affected)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Entry-point detection
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// Return the set of fully-qualified symbols in `repository_id` that are
+    /// entry points (zero callers, or matching a well-known name pattern).
+    async fn find_entry_points(&self, repository_id: &str) -> Result<Vec<String>, DomainError> {
+        let all_refs = self.call_graph.find_by_repository(repository_id).await?;
+
+        // Collect every symbol that appears as a caller and every symbol that
+        // appears as a callee.
+        let mut callee_symbols: HashSet<String> = HashSet::new();
+        let mut caller_symbols: HashSet<String> = HashSet::new();
+
+        // Also track location information for each caller symbol (first seen).
+        let mut caller_file: HashMap<String, String> = HashMap::new();
+
+        for r in &all_refs {
+            callee_symbols.insert(r.callee_symbol().to_string());
+            if let Some(caller) = r.caller_symbol() {
+                let caller = caller.to_string();
+                caller_file
+                    .entry(caller.clone())
+                    .or_insert_with(|| r.caller_file_path().to_string());
+                caller_symbols.insert(caller);
+            }
+        }
+
+        // A symbol is an entry point when it:
+        //   (a) appears as a caller (it calls something) AND
+        //   (b) does NOT appear as a callee (nothing calls it),
+        //       OR its short name matches a well-known entry-point pattern.
+        let mut entry_points: Vec<String> = caller_symbols
+            .iter()
+            .filter(|sym| {
+                let not_called = !callee_symbols.contains(*sym);
+                let name_match = short_name_is_entry_point(sym);
+                not_called || name_match
+            })
+            .cloned()
+            .collect();
+
+        entry_points.sort();
+        Ok(entry_points)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Feature construction
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// Build an `ExecutionFeature` for `entry_point` in `repository_id` by
+    /// running a forward BFS through the call graph and scoring the result.
+    async fn build_feature(
+        &self,
+        entry_point: &str,
+        repository_id: &str,
+    ) -> Result<ExecutionFeature, DomainError> {
+        let query = CallGraphQuery::new().with_repository(repository_id);
+
+        // ── Forward BFS ────────────────────────────────────────────────────
+        let mut visited: HashSet<String> = HashSet::new();
+        let mut queue: VecDeque<(String, usize, String, u32)> = VecDeque::new();
+
+        visited.insert(entry_point.to_string());
+        queue.push_back((entry_point.to_string(), 0, String::new(), 0));
+
+        let mut path: Vec<FeatureNode> = Vec::new();
+        let mut unresolved_callees: usize = 0;
+        let mut total_callees_seen: usize = 0;
+
+        while let Some((current, depth, file_path, line)) = queue.pop_front() {
+            path.push(FeatureNode {
+                symbol: current.clone(),
+                file_path,
+                line,
+                depth,
+                repository_id: repository_id.to_string(),
+            });
+
+            let callees = self.call_graph.find_callees(&current, &query).await?;
+            for reference in &callees {
+                total_callees_seen += 1;
+                let callee = reference.callee_symbol().to_string();
+                if visited.contains(&callee) {
+                    continue;
+                }
+                visited.insert(callee.clone());
+
+                // A callee is considered "external" (unresolved) when it does
+                // not appear as a caller_symbol anywhere in this repository's
+                // call graph — i.e. we have no outgoing edges for it.
+                // We approximate this by checking whether we've seen it as a
+                // caller; the check is done lazily after the BFS.
+                queue.push_back((
+                    callee,
+                    depth + 1,
+                    reference.reference_file_path().to_string(),
+                    reference.reference_line(),
+                ));
+            }
+        }
+
+        // Count unresolved callees: leaf nodes in the forward BFS (excluding the
+        // entry point) that produced no further callees — a proxy for external or
+        // stdlib calls that we could not trace further.
+        for node in path.iter().skip(1) {
+            // leaf nodes that the BFS couldn't expand
+            let has_callees_in_path = path.iter().any(|n| n.depth == node.depth + 1);
+            if !has_callees_in_path && node.depth == path.iter().map(|n| n.depth).max().unwrap_or(0) {
+                unresolved_callees += 1;
+            }
+        }
+        // Fallback: if total_callees_seen is 0 avoid division by zero.
+        if total_callees_seen == 0 {
+            total_callees_seen = 1;
+        }
+
+        // ── Criticality scoring ────────────────────────────────────────────
+        let total_nodes = path.len().max(1);
+        let distinct_files: HashSet<&str> = path.iter().map(|n| n.file_path.as_str()).collect();
+        let file_count = distinct_files.len();
+        let feature_depth = path.iter().map(|n| n.depth).max().unwrap_or(0);
+
+        // Signal 1 — file spread
+        let file_spread_score = (file_count as f32 / total_nodes as f32).min(1.0);
+
+        // Signal 2 — security sensitivity
+        let security_score = if path.iter().any(|n| is_security_sensitive(&n.symbol)) {
+            1.0_f32
+        } else {
+            0.0_f32
+        };
+
+        // Signal 3 — external calls
+        let external_score = (unresolved_callees as f32 / total_callees_seen as f32).min(1.0);
+
+        // Signal 4 — test coverage gap
+        // Check whether any test symbol is a direct or indirect caller of the entry point.
+        let callers_query = CallGraphQuery::new().with_repository(repository_id);
+        let callers_of_entry = self
+            .call_graph
+            .find_callers(entry_point, &callers_query)
+            .await
+            .unwrap_or_default();
+        let has_test_caller = callers_of_entry.iter().any(|r| {
+            r.caller_symbol()
+                .map(|s| is_test_symbol(s))
+                .unwrap_or(false)
+        });
+        let test_gap_score = if has_test_caller {
+            TEST_COVERAGE_PRESENT_SCORE
+        } else {
+            TEST_COVERAGE_GAP_SCORE
+        };
+
+        // Signal 5 — depth
+        let depth_score = (feature_depth as f32 / DEPTH_REFERENCE).min(1.0);
+
+        let criticality = (WEIGHT_FILE_SPREAD * file_spread_score
+            + WEIGHT_SECURITY * security_score
+            + WEIGHT_EXTERNAL_CALLS * external_score
+            + WEIGHT_TEST_COVERAGE_GAP * test_gap_score
+            + WEIGHT_DEPTH * depth_score)
+            .min(1.0_f32);
+
+        let name = short_name(entry_point);
+        let id = format!("{}:{}", repository_id, entry_point);
+
+        Ok(ExecutionFeature {
+            id,
+            name,
+            entry_point: entry_point.to_string(),
+            repository_id: repository_id.to_string(),
+            file_count,
+            depth: feature_depth,
+            path,
+            criticality,
+        })
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Extract the short (human-readable) name from a fully-qualified symbol.
+///
+/// Strips everything up to and including the last `/`, `#`, `.`, or `::`.
+fn short_name(fqn: &str) -> String {
+    // Handle SCIP-style `path/to/file Package#Method`.
+    let base = fqn.rsplit_once('#').map(|(_, r)| r).unwrap_or(fqn);
+    // Handle `::` separators (Rust, C++).
+    let base = base.rsplit_once("::").map(|(_, r)| r).unwrap_or(base);
+    // Handle `.` separators (Python, Java).
+    let base = base.rsplit_once('.').map(|(_, r)| r).unwrap_or(base);
+    // Strip trailing `()` or generic parameters.
+    let base = base.split('(').next().unwrap_or(base);
+    let base = base.split('<').next().unwrap_or(base);
+    base.trim().to_string()
+}
+
+/// Return `true` when the short name of `fqn` matches a well-known entry-point
+/// pattern (exact names or prefixes).
+fn short_name_is_entry_point(fqn: &str) -> bool {
+    let sn = short_name(fqn);
+    let sn_lower = sn.to_lowercase();
+    if ENTRY_POINT_EXACT.iter().any(|&e| sn_lower == e) {
+        return true;
+    }
+    ENTRY_POINT_PREFIXES
+        .iter()
+        .any(|&p| sn_lower.starts_with(p))
+}
+
+/// Return `true` when a symbol looks like a test function.
+fn is_test_symbol(symbol: &str) -> bool {
+    let sn = short_name(symbol);
+    let sn_lower = sn.to_lowercase();
+    sn_lower.starts_with("test_") || sn_lower.starts_with("it_")
+}
+
+/// Return `true` when a symbol contains a security-sensitive keyword.
+fn is_security_sensitive(symbol: &str) -> bool {
+    let lower = symbol.to_lowercase();
+    SECURITY_KEYWORDS.iter().any(|&kw| lower.contains(kw))
+}

--- a/src/application/use_cases/execution_features.rs
+++ b/src/application/use_cases/execution_features.rs
@@ -17,10 +17,9 @@ const WEIGHT_DEPTH: f32 = 0.15;
 /// depth scores 1.0 on the depth signal; deeper paths are clamped to 1.0.
 const DEPTH_REFERENCE: f32 = 20.0;
 
-/// Score assigned when no test symbol directly calls the entry point.
+/// Baseline test-coverage-gap score. Entry points by structural definition
+/// have no callers in the repository, so the gap always applies uniformly.
 const TEST_COVERAGE_GAP_SCORE: f32 = 0.30;
-/// Score assigned when a test caller IS present.
-const TEST_COVERAGE_PRESENT_SCORE: f32 = 0.05;
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Use case
@@ -56,7 +55,7 @@ impl ExecutionFeaturesUseCase {
             features.push(feature);
         }
 
-        features.sort_by(|a, b| b.criticality.partial_cmp(&a.criticality).unwrap_or(std::cmp::Ordering::Equal));
+        features.sort_by(|a, b| b.criticality.total_cmp(&a.criticality));
         features.truncate(limit);
         Ok(features)
     }
@@ -169,7 +168,7 @@ impl ExecutionFeaturesUseCase {
             }
         }
 
-        affected.sort_by(|a, b| b.criticality.partial_cmp(&a.criticality).unwrap_or(std::cmp::Ordering::Equal));
+        affected.sort_by(|a, b| b.criticality.total_cmp(&a.criticality));
         Ok(affected)
     }
 
@@ -317,23 +316,9 @@ impl ExecutionFeaturesUseCase {
         // this repo) to all callee references seen during BFS.
         let external_score = (unresolved_callees as f32 / total_callees_seen as f32).min(1.0);
 
-        // Signal 3 — test coverage gap: high when nothing directly calls the
-        // entry point with a test_ / it_ prefix.
-        let callers_query = CallGraphQuery::new().with_repository(repository_id);
-        let callers_of_entry = self
-            .call_graph
-            .find_callers(entry_point, &callers_query)
-            .await?;
-        let has_test_caller = callers_of_entry.iter().any(|r| {
-            r.caller_symbol()
-                .map(|s| is_test_symbol(s))
-                .unwrap_or(false)
-        });
-        let test_gap_score = if has_test_caller {
-            TEST_COVERAGE_PRESENT_SCORE
-        } else {
-            TEST_COVERAGE_GAP_SCORE
-        };
+        // Signal 3 — test coverage gap. Entry points have no callers in the
+        // repository by definition, so the gap score applies unconditionally.
+        let test_gap_score = TEST_COVERAGE_GAP_SCORE;
 
         // Signal 4 — depth: normalised call-chain length.
         let depth_score = (feature_depth as f32 / DEPTH_REFERENCE).min(1.0);
@@ -378,11 +363,4 @@ fn short_name(fqn: &str) -> String {
     let base = base.split('(').next().unwrap_or(base);
     let base = base.split('<').next().unwrap_or(base);
     base.trim().to_string()
-}
-
-/// Return `true` when a symbol looks like a test function.
-fn is_test_symbol(symbol: &str) -> bool {
-    let sn = short_name(symbol);
-    let sn_lower = sn.to_lowercase();
-    sn_lower.starts_with("test_") || sn_lower.starts_with("it_")
 }

--- a/src/application/use_cases/execution_features.rs
+++ b/src/application/use_cases/execution_features.rs
@@ -120,7 +120,7 @@ impl ExecutionFeaturesUseCase {
 
     /// Given a set of changed symbols, return every feature whose call chain
     /// includes at least one of them, sorted by descending criticality.
-    pub async fn get_affected_features(
+    pub async fn get_impacted_features(
         &self,
         changed_symbols: &[String],
         repository_id: Option<&str>,

--- a/src/application/use_cases/mod.rs
+++ b/src/application/use_cases/mod.rs
@@ -1,5 +1,6 @@
 mod call_graph;
 mod delete_repository;
+mod execution_features;
 mod explain;
 mod file_relationship;
 mod impact_analysis;
@@ -13,6 +14,7 @@ mod symbol_context;
 
 pub use call_graph::*;
 pub use delete_repository::*;
+pub use execution_features::*;
 pub use explain::*;
 pub use file_relationship::*;
 pub use impact_analysis::*;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,52 @@
 use clap::{Subcommand, ValueEnum};
 
+/// Subcommands for the `features` command.
+#[derive(Subcommand)]
+pub enum FeaturesSubcommand {
+    /// List all entry-point features for a repository, sorted by criticality.
+    List {
+        /// Repository ID to analyse.
+        repository: String,
+
+        /// Maximum number of features to return.
+        #[arg(short, long, default_value = "20")]
+        limit: usize,
+
+        /// Output format: text, json, or vimgrep
+        #[arg(short = 'F', long, value_enum, default_value = "text")]
+        format: OutputFormat,
+    },
+
+    /// Show the execution feature for a single entry-point symbol.
+    Get {
+        /// Entry-point symbol name (exact or substring).
+        symbol: String,
+
+        /// Restrict lookup to a specific repository ID.
+        #[arg(short, long)]
+        repository: Option<String>,
+
+        /// Output format: text, json, or vimgrep
+        #[arg(short = 'F', long, value_enum, default_value = "text")]
+        format: OutputFormat,
+    },
+
+    /// Show features affected by a set of changed symbols.
+    Affected {
+        /// One or more changed symbol names.
+        #[arg(required = true)]
+        symbols: Vec<String>,
+
+        /// Restrict lookup to a specific repository ID.
+        #[arg(short, long)]
+        repository: Option<String>,
+
+        /// Output format: text, json, or vimgrep
+        #[arg(short = 'F', long, value_enum, default_value = "text")]
+        format: OutputFormat,
+    },
+}
+
 /// Output format for search results.
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
 pub enum OutputFormat {
@@ -188,6 +235,13 @@ pub enum Commands {
         /// you want to control anchoring yourself (e.g. "^MyNs/.*Service#get$").
         #[arg(long)]
         regex: bool,
+    },
+
+    /// Discover and score execution features — forward call chains rooted at
+    /// entry-point symbols — and rank them by criticality.
+    Features {
+        #[command(subcommand)]
+        subcommand: FeaturesSubcommand,
     },
 
     /// List the files that repository X uses from repository Y.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -31,8 +31,8 @@ pub enum FeaturesSubcommand {
         format: OutputFormat,
     },
 
-    /// Show features affected by a set of changed symbols.
-    Affected {
+    /// Show features impacted by a set of changed symbols.
+    Impacted {
         /// One or more changed symbol names.
         #[arg(required = true)]
         symbols: Vec<String>,

--- a/src/connector/api/container.rs
+++ b/src/connector/api/container.rs
@@ -14,10 +14,10 @@ use crate::connector::adapter::NamespaceEmbeddingConfig;
 use crate::{
     AnthropicClient, AnthropicReranking, DeleteRepositoryUseCase, DuckdbCallGraphRepository,
     DuckdbFileHashRepository, DuckdbMetadataRepository, DuckdbVectorRepository, EmbeddingService,
-    ExplainUseCase, FileRelationshipUseCase, ImpactAnalysisUseCase, InMemoryVectorRepository,
-    IndexRepositoryUseCase, ListRepositoriesUseCase, LlmQueryExpander, MockEmbedding,
-    MockReranking, OpenAiChatClient, OpenAiEmbedding, OpenAiReranking, OrtEmbedding, OrtReranking,
-    RerankingService, Scip, SearchCodeUseCase, SnippetLookupUseCase,
+    ExecutionFeaturesUseCase, ExplainUseCase, FileRelationshipUseCase, ImpactAnalysisUseCase,
+    InMemoryVectorRepository, IndexRepositoryUseCase, ListRepositoriesUseCase, LlmQueryExpander,
+    MockEmbedding, MockReranking, OpenAiChatClient, OpenAiEmbedding, OpenAiReranking, OrtEmbedding,
+    OrtReranking, RerankingService, Scip, SearchCodeUseCase, SnippetLookupUseCase,
     SymbolContextUseCase, TreeSitterParser, VectorRepository,
 };
 
@@ -519,6 +519,10 @@ impl Container {
             self.vector_repo.clone(),
             self.metadata_repository(),
         )
+    }
+
+    pub fn execution_features_use_case(&self) -> ExecutionFeaturesUseCase {
+        ExecutionFeaturesUseCase::new(self.call_graph_use_case.clone())
     }
 
     pub fn data_dir(&self) -> &str {

--- a/src/connector/api/controller/execution_features_controller.rs
+++ b/src/connector/api/controller/execution_features_controller.rs
@@ -44,7 +44,11 @@ impl<'a> ExecutionFeaturesController<'a> {
             .await?;
 
         match result {
-            None => Ok(format!("No entry-point feature found for '{symbol}'.")),
+            None => Ok(match format {
+                OutputFormat::Json => "null".to_string(),
+                OutputFormat::Vimgrep => String::new(),
+                OutputFormat::Text => format!("No entry-point feature found for '{symbol}'."),
+            }),
             Some(feature) => Ok(match format {
                 OutputFormat::Json => serde_json::to_string_pretty(&feature)?,
                 OutputFormat::Vimgrep => Self::format_feature_vimgrep(&feature),
@@ -65,17 +69,19 @@ impl<'a> ExecutionFeaturesController<'a> {
             .get_impacted_features(&symbols, repository.as_deref())
             .await?;
 
-        if features.is_empty() {
-            return Ok(format!(
-                "No features impacted by the provided symbol(s): {}",
-                symbols.join(", ")
-            ));
-        }
-
         Ok(match format {
             OutputFormat::Json => serde_json::to_string_pretty(&features)?,
             OutputFormat::Vimgrep => Self::format_list_vimgrep(&features),
-            OutputFormat::Text => Self::format_list_text(&features),
+            OutputFormat::Text => {
+                if features.is_empty() {
+                    format!(
+                        "No features impacted by the provided symbol(s): {}",
+                        symbols.join(", ")
+                    )
+                } else {
+                    Self::format_list_text(&features)
+                }
+            }
         })
     }
 

--- a/src/connector/api/controller/execution_features_controller.rs
+++ b/src/connector/api/controller/execution_features_controller.rs
@@ -1,0 +1,172 @@
+use anyhow::Result;
+
+use crate::cli::OutputFormat;
+use crate::domain::ExecutionFeature;
+
+use super::super::Container;
+
+pub struct ExecutionFeaturesController<'a> {
+    container: &'a Container,
+}
+
+impl<'a> ExecutionFeaturesController<'a> {
+    pub fn new(container: &'a Container) -> Self {
+        Self { container }
+    }
+
+    /// List entry-point features for `repository_id`, sorted by descending criticality.
+    pub async fn list(
+        &self,
+        repository: String,
+        limit: usize,
+        format: OutputFormat,
+    ) -> Result<String> {
+        let use_case = self.container.execution_features_use_case();
+        let features = use_case.list_features(&repository, limit).await?;
+
+        Ok(match format {
+            OutputFormat::Json => serde_json::to_string_pretty(&features)?,
+            OutputFormat::Vimgrep => Self::format_list_vimgrep(&features),
+            OutputFormat::Text => Self::format_list_text(&features),
+        })
+    }
+
+    /// Retrieve a single feature by entry-point symbol name.
+    pub async fn get(
+        &self,
+        symbol: String,
+        repository: Option<String>,
+        format: OutputFormat,
+    ) -> Result<String> {
+        let use_case = self.container.execution_features_use_case();
+        let result = use_case
+            .get_feature(&symbol, repository.as_deref())
+            .await?;
+
+        match result {
+            None => Ok(format!("No entry-point feature found for '{symbol}'.")),
+            Some(feature) => Ok(match format {
+                OutputFormat::Json => serde_json::to_string_pretty(&feature)?,
+                OutputFormat::Vimgrep => Self::format_feature_vimgrep(&feature),
+                OutputFormat::Text => Self::format_feature_text(&feature),
+            }),
+        }
+    }
+
+    /// Show features affected by a set of changed symbols.
+    pub async fn affected(
+        &self,
+        symbols: Vec<String>,
+        repository: Option<String>,
+        format: OutputFormat,
+    ) -> Result<String> {
+        let use_case = self.container.execution_features_use_case();
+        let features = use_case
+            .get_affected_features(&symbols, repository.as_deref())
+            .await?;
+
+        if features.is_empty() {
+            return Ok(format!(
+                "No features affected by the provided symbol(s): {}",
+                symbols.join(", ")
+            ));
+        }
+
+        Ok(match format {
+            OutputFormat::Json => serde_json::to_string_pretty(&features)?,
+            OutputFormat::Vimgrep => Self::format_list_vimgrep(&features),
+            OutputFormat::Text => Self::format_list_text(&features),
+        })
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Formatters
+    // ──────────────────────────────────────────────────────────────────────────
+
+    fn format_list_text(features: &[ExecutionFeature]) -> String {
+        if features.is_empty() {
+            return "No execution features found.".to_string();
+        }
+
+        let mut out = format!(
+            "Execution Features ({} total)\n\
+             ─────────────────────────────────────────\n",
+            features.len()
+        );
+
+        for feature in features {
+            out.push_str(&format!(
+                "{name}  criticality={crit:.2}  depth={depth}  files={files}\n  entry: {ep}\n\n",
+                name = feature.name,
+                crit = feature.criticality,
+                depth = feature.depth,
+                files = feature.file_count,
+                ep = feature.entry_point,
+            ));
+        }
+
+        out
+    }
+
+    fn format_list_vimgrep(features: &[ExecutionFeature]) -> String {
+        features
+            .iter()
+            .filter_map(|f| f.path.first())
+            .map(|node| {
+                format!(
+                    "{}:{}:1:{}",
+                    node.file_path, node.line, node.symbol
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn format_feature_text(feature: &ExecutionFeature) -> String {
+        let mut out = format!(
+            "Execution Feature: {name}\n\
+             ─────────────────────────────────────────\n\
+             Entry point : {ep}\n\
+             Repository  : {repo}\n\
+             Criticality : {crit:.2}\n\
+             Depth       : {depth}\n\
+             Files       : {files}\n\
+             \n\
+             Call chain:\n",
+            name = feature.name,
+            ep = feature.entry_point,
+            repo = feature.repository_id,
+            crit = feature.criticality,
+            depth = feature.depth,
+            files = feature.file_count,
+        );
+
+        for node in &feature.path {
+            let indent = "    ".repeat(node.depth);
+            if node.depth == 0 {
+                out.push_str(&format!("{}\n", node.symbol));
+            } else {
+                out.push_str(&format!(
+                    "{}└── {} [{}:{}]\n",
+                    indent, node.symbol, node.file_path, node.line
+                ));
+            }
+        }
+
+        out
+    }
+
+    fn format_feature_vimgrep(feature: &ExecutionFeature) -> String {
+        feature
+            .path
+            .iter()
+            .map(|node| {
+                format!(
+                    "{}:{}:1:{}",
+                    node.file_path, node.line, node.symbol
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}

--- a/src/connector/api/controller/execution_features_controller.rs
+++ b/src/connector/api/controller/execution_features_controller.rs
@@ -53,8 +53,8 @@ impl<'a> ExecutionFeaturesController<'a> {
         }
     }
 
-    /// Show features affected by a set of changed symbols.
-    pub async fn affected(
+    /// Show features impacted by a set of changed symbols.
+    pub async fn impacted(
         &self,
         symbols: Vec<String>,
         repository: Option<String>,
@@ -62,12 +62,12 @@ impl<'a> ExecutionFeaturesController<'a> {
     ) -> Result<String> {
         let use_case = self.container.execution_features_use_case();
         let features = use_case
-            .get_affected_features(&symbols, repository.as_deref())
+            .get_impacted_features(&symbols, repository.as_deref())
             .await?;
 
         if features.is_empty() {
             return Ok(format!(
-                "No features affected by the provided symbol(s): {}",
+                "No features impacted by the provided symbol(s): {}",
                 symbols.join(", ")
             ));
         }

--- a/src/connector/api/controller/mod.rs
+++ b/src/connector/api/controller/mod.rs
@@ -1,19 +1,21 @@
 pub mod delete_controller;
+pub mod execution_features_controller;
 pub mod explain_controller;
 pub mod impact_controller;
 pub mod index_controller;
 pub mod list_repositories_controller;
 pub mod search_controller;
 pub mod stats_controller;
-pub mod uses_controller;
 pub mod symbol_context_controller;
+pub mod uses_controller;
 
 pub use delete_controller::DeleteController;
+pub use execution_features_controller::ExecutionFeaturesController;
 pub use explain_controller::ExplainController;
 pub use impact_controller::ImpactController;
 pub use index_controller::IndexController;
 pub use list_repositories_controller::ListRepositoriesController;
 pub use search_controller::SearchController;
 pub use stats_controller::StatsController;
-pub use uses_controller::UsesController;
 pub use symbol_context_controller::SymbolContextController;
+pub use uses_controller::UsesController;

--- a/src/connector/api/router.rs
+++ b/src/connector/api/router.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
 
-use crate::Commands;
+use crate::{Commands, FeaturesSubcommand};
 
 use super::container::Container;
 use super::controller::{
-    DeleteController, ExplainController, ImpactController, IndexController,
-    ListRepositoriesController, SearchController, StatsController, UsesController,
-    SymbolContextController,
+    DeleteController, ExecutionFeaturesController, ExplainController, ImpactController,
+    IndexController, ListRepositoriesController, SearchController, StatsController,
+    SymbolContextController, UsesController,
 };
 
 pub struct Router<'a> {
@@ -19,6 +19,7 @@ pub struct Router<'a> {
     list_repositories_controller: ListRepositoriesController<'a>,
     delete_controller: DeleteController<'a>,
     uses_controller: UsesController<'a>,
+    execution_features_controller: ExecutionFeaturesController<'a>,
 }
 
 impl<'a> Router<'a> {
@@ -33,6 +34,7 @@ impl<'a> Router<'a> {
             list_repositories_controller: ListRepositoriesController::new(container),
             delete_controller: DeleteController::new(container),
             uses_controller: UsesController::new(container),
+            execution_features_controller: ExecutionFeaturesController::new(container),
         }
     }
 
@@ -96,6 +98,35 @@ impl<'a> Router<'a> {
                     .explain(symbol, repository, llm, dump_symbols, regex)
                     .await
             }
+            Commands::Features { subcommand } => match subcommand {
+                FeaturesSubcommand::List {
+                    repository,
+                    limit,
+                    format,
+                } => {
+                    self.execution_features_controller
+                        .list(repository, limit, format)
+                        .await
+                }
+                FeaturesSubcommand::Get {
+                    symbol,
+                    repository,
+                    format,
+                } => {
+                    self.execution_features_controller
+                        .get(symbol, repository, format)
+                        .await
+                }
+                FeaturesSubcommand::Affected {
+                    symbols,
+                    repository,
+                    format,
+                } => {
+                    self.execution_features_controller
+                        .affected(symbols, repository, format)
+                        .await
+                }
+            },
             Commands::Uses { from, to } => self.uses_controller.uses(from, to).await,
             Commands::Mcp { .. } => {
                 Err(anyhow::anyhow!("MCP command is handled separately in main"))

--- a/src/connector/api/router.rs
+++ b/src/connector/api/router.rs
@@ -117,13 +117,13 @@ impl<'a> Router<'a> {
                         .get(symbol, repository, format)
                         .await
                 }
-                FeaturesSubcommand::Affected {
+                FeaturesSubcommand::Impacted {
                     symbols,
                     repository,
                     format,
                 } => {
                     self.execution_features_controller
-                        .affected(symbols, repository, format)
+                        .impacted(symbols, repository, format)
                         .await
                 }
             },

--- a/src/domain/models/execution_feature.rs
+++ b/src/domain/models/execution_feature.rs
@@ -1,0 +1,40 @@
+use serde::{Deserialize, Serialize};
+
+/// A single node in the forward call chain of an execution feature.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeatureNode {
+    /// The fully-qualified symbol name.
+    pub symbol: String,
+    /// Source file where this symbol is declared.
+    pub file_path: String,
+    /// Line number where the reference occurs.
+    pub line: u32,
+    /// BFS depth from the entry point (0 = entry point itself).
+    pub depth: usize,
+    /// Repository that contains this symbol.
+    pub repository_id: String,
+}
+
+/// An execution feature: a named forward call chain starting from an entry-point
+/// symbol, annotated with a criticality score.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionFeature {
+    /// Stable identifier derived from the entry-point symbol and repository.
+    pub id: String,
+    /// Human-readable label (short name of the entry-point symbol).
+    pub name: String,
+    /// Fully-qualified entry-point symbol name.
+    pub entry_point: String,
+    /// Repository this feature belongs to.
+    pub repository_id: String,
+    /// Ordered call chain starting at the entry point (index 0) and tracing
+    /// forward through callees via BFS.
+    pub path: Vec<FeatureNode>,
+    /// `len(path) - 1` — number of hops from entry point to deepest reachable symbol.
+    pub depth: usize,
+    /// Number of distinct source files touched by the call chain.
+    pub file_count: usize,
+    /// Composite criticality score in the range 0.0–1.0.  Higher values indicate
+    /// paths that are more important to understand before making changes.
+    pub criticality: f32,
+}

--- a/src/domain/models/mod.rs
+++ b/src/domain/models/mod.rs
@@ -1,5 +1,6 @@
 mod code_chunk;
 mod embedding;
+mod execution_feature;
 mod file_graph;
 mod file_hash;
 mod language;
@@ -9,6 +10,7 @@ mod symbol_reference;
 
 pub use code_chunk::*;
 pub use embedding::*;
+pub use execution_feature::*;
 pub use file_graph::*;
 pub use file_hash::*;
 pub use language::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,15 +6,16 @@ pub mod tui;
 
 pub use application::{
     CallGraphQuery, CallGraphRepository, CallGraphStats, CallGraphUseCase, ChatClient, ContextNode,
-    DeleteRepositoryUseCase, EmbeddingService, ExplainResult, ExplainUseCase, FileHashRepository,
-    FileRelationshipUseCase, ImpactAnalysis, ImpactAnalysisUseCase, ImpactNode,
-    IndexRepositoryUseCase, ListRepositoriesUseCase, MetadataRepository, ParserService,
-    QueryExpander, RerankingService, Scip, SearchCodeUseCase, SnippetLookupUseCase,
-    SymbolContext, SymbolContextUseCase, VectorRepository,
+    DeleteRepositoryUseCase, EmbeddingService, ExecutionFeaturesUseCase, ExplainResult,
+    ExplainUseCase, FileHashRepository, FileRelationshipUseCase, ImpactAnalysis,
+    ImpactAnalysisUseCase, ImpactNode, IndexRepositoryUseCase, ListRepositoriesUseCase,
+    MetadataRepository, ParserService, QueryExpander, RerankingService, Scip, SearchCodeUseCase,
+    SnippetLookupUseCase, SymbolContext, SymbolContextUseCase, VectorRepository,
 };
 
 pub use cli::{
-    Commands, EmbeddingTarget, LlmTarget, OutputFormat, RerankingTarget, TuiMode,
+    Commands, EmbeddingTarget, FeaturesSubcommand, LlmTarget, OutputFormat, RerankingTarget,
+    TuiMode,
 };
 
 pub use connector::{
@@ -25,9 +26,9 @@ pub use connector::{
 };
 
 pub use domain::{
-    compute_file_hash, CodeChunk, DomainError, Embedding, EmbeddingConfig, FileHash,
-    IndexingStatus, Language, NodeType, ReferenceKind, Repository, SearchQuery, SearchResult,
-    SymbolReference, VectorStore,
+    compute_file_hash, CodeChunk, DomainError, Embedding, EmbeddingConfig, ExecutionFeature,
+    FeatureNode, FileHash, IndexingStatus, Language, NodeType, ReferenceKind, Repository,
+    SearchQuery, SearchResult, SymbolReference, VectorStore,
 };
 
 pub use connector::api::{Container, ContainerConfig, Router};

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,6 +165,7 @@ async fn main() -> Result<()> {
                 | Commands::Impact { .. }
                 | Commands::Context { .. }
                 | Commands::Explain { .. }
+                | Commands::Features { .. }
                 | Commands::Uses { .. }
                 | Commands::Tui { .. }
         );

--- a/tests/execution_features_tests.rs
+++ b/tests/execution_features_tests.rs
@@ -1,0 +1,592 @@
+use std::sync::Arc;
+
+use codesearch::{
+    CallGraphRepository, CallGraphUseCase, DuckdbCallGraphRepository, DuckdbMetadataRepository,
+    ExecutionFeaturesUseCase, Language, ReferenceKind, SymbolReference,
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Shared setup helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+async fn make_call_graph_use_case() -> Arc<CallGraphUseCase> {
+    let metadata_repository =
+        Arc::new(DuckdbMetadataRepository::in_memory().expect("Failed to create DuckDB"));
+    let shared_conn = metadata_repository.shared_connection();
+    let call_graph_repo: Arc<dyn CallGraphRepository> = Arc::new(
+        DuckdbCallGraphRepository::with_connection(shared_conn)
+            .await
+            .expect("Failed to create call graph repo"),
+    );
+    Arc::new(CallGraphUseCase::new(call_graph_repo))
+}
+
+/// Shorthand for building a simple call edge.
+fn call_ref(
+    caller: &str,
+    callee: &str,
+    file: &str,
+    line: u32,
+    repo: &str,
+) -> SymbolReference {
+    SymbolReference::new(
+        Some(caller.to_string()),
+        callee.to_string(),
+        file.to_string(),
+        file.to_string(),
+        line,
+        0,
+        ReferenceKind::Call,
+        Language::Rust,
+        repo.to_string(),
+    )
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Entry-point detection
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// A symbol with zero callers that also calls at least one other symbol is the
+/// classic entry-point case and must appear in `list_features`.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_zero_caller_symbol_is_entry_point() {
+    let cg = make_call_graph_use_case().await;
+    // main → foo → bar
+    let refs = vec![
+        call_ref("main", "foo", "src/main.rs", 1, "repo1"),
+        call_ref("foo", "bar", "src/foo.rs", 5, "repo1"),
+    ];
+    cg.save_references(&refs).await.expect("seed failed");
+
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    let features = uc
+        .list_features("repo1", 100)
+        .await
+        .expect("list_features failed");
+
+    // `main` is the only zero-caller symbol that calls others.
+    let entry_points: Vec<&str> = features.iter().map(|f| f.entry_point.as_str()).collect();
+    assert!(
+        entry_points.contains(&"main"),
+        "expected 'main' as an entry point, got: {:?}",
+        entry_points
+    );
+}
+
+/// A symbol whose short name matches a well-known pattern (e.g. `handle_request`)
+/// is flagged as an entry point even when it does have callers.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_well_known_name_is_entry_point_even_with_callers() {
+    let cg = make_call_graph_use_case().await;
+    // dispatcher calls handle_request, and handle_request calls process_data.
+    // handle_request HAS a caller (dispatcher) but its name matches the
+    // `handle_*` prefix pattern — it should still surface as an entry point.
+    let refs = vec![
+        call_ref(
+            "dispatcher",
+            "handle_request",
+            "src/dispatcher.rs",
+            10,
+            "repo1",
+        ),
+        call_ref(
+            "handle_request",
+            "process_data",
+            "src/handler.rs",
+            20,
+            "repo1",
+        ),
+    ];
+    cg.save_references(&refs).await.expect("seed failed");
+
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    let features = uc
+        .list_features("repo1", 100)
+        .await
+        .expect("list_features failed");
+
+    let entry_points: Vec<&str> = features.iter().map(|f| f.entry_point.as_str()).collect();
+    assert!(
+        entry_points.contains(&"handle_request"),
+        "handle_request should be an entry point due to name pattern; got: {:?}",
+        entry_points
+    );
+}
+
+/// Symbols that only appear as callees (never as callers) are not entry points.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pure_callee_is_not_entry_point() {
+    let cg = make_call_graph_use_case().await;
+    // main → leaf (leaf never calls anyone, main has no callers)
+    let refs = vec![call_ref("main", "leaf", "src/main.rs", 1, "repo1")];
+    cg.save_references(&refs).await.expect("seed failed");
+
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    let features = uc
+        .list_features("repo1", 100)
+        .await
+        .expect("list_features failed");
+
+    // `leaf` should NOT be an entry point — it is only a callee.
+    let entry_points: Vec<&str> = features.iter().map(|f| f.entry_point.as_str()).collect();
+    assert!(
+        !entry_points.contains(&"leaf"),
+        "'leaf' must not be an entry point; got: {:?}",
+        entry_points
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Forward BFS / path construction
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// The feature path must contain all symbols reachable from the entry point in
+/// BFS order, with the entry point itself at index 0 (depth 0).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_feature_path_depth_and_order() {
+    let cg = make_call_graph_use_case().await;
+    // Linear chain: main → a → b → c
+    let refs = vec![
+        call_ref("main", "a", "src/main.rs", 1, "repo1"),
+        call_ref("a", "b", "src/a.rs", 5, "repo1"),
+        call_ref("b", "c", "src/b.rs", 10, "repo1"),
+    ];
+    cg.save_references(&refs).await.expect("seed failed");
+
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    let feature = uc
+        .get_feature("main", Some("repo1"))
+        .await
+        .expect("get_feature failed")
+        .expect("feature should exist");
+
+    // Entry point is at depth 0 and is the first node.
+    assert_eq!(feature.path[0].symbol, "main");
+    assert_eq!(feature.path[0].depth, 0);
+
+    // All symbols in the chain must appear.
+    let syms: Vec<&str> = feature.path.iter().map(|n| n.symbol.as_str()).collect();
+    assert!(syms.contains(&"a"), "path missing 'a'");
+    assert!(syms.contains(&"b"), "path missing 'b'");
+    assert!(syms.contains(&"c"), "path missing 'c'");
+
+    // Reported depth equals the deepest depth seen.
+    assert_eq!(feature.depth, 3, "chain of 3 hops → depth 3");
+}
+
+/// `file_count` must equal the number of distinct files touched by the path.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_feature_file_count() {
+    let cg = make_call_graph_use_case().await;
+    // Three separate files.
+    let refs = vec![
+        call_ref("main", "a", "src/main.rs", 1, "repo1"),
+        call_ref("a", "b", "src/a.rs", 5, "repo1"),
+        call_ref("b", "c", "src/b.rs", 10, "repo1"),
+    ];
+    cg.save_references(&refs).await.expect("seed failed");
+
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    let feature = uc
+        .get_feature("main", Some("repo1"))
+        .await
+        .expect("get_feature failed")
+        .expect("feature should exist");
+
+    // Nodes: main (src/main.rs), a (src/a.rs via ref file), b (src/b.rs), c (leaf)
+    // Exact count depends on how file_path is recorded, but must be ≥ 1.
+    assert!(feature.file_count >= 1, "file_count must be at least 1");
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Cycle detection
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// A mutually recursive cycle (A ↔ B) must not cause infinite BFS traversal.
+/// The use case must terminate and return a finite path.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cycle_guard_mutual_recursion() {
+    let cg = make_call_graph_use_case().await;
+    // A calls B, B calls A (mutual recursion / cycle)
+    let refs = vec![
+        call_ref("run", "A", "src/run.rs", 1, "repo1"),
+        call_ref("A", "B", "src/a.rs", 5, "repo1"),
+        call_ref("B", "A", "src/b.rs", 10, "repo1"),
+    ];
+    cg.save_references(&refs).await.expect("seed failed");
+
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    // Must not hang or panic.
+    let feature = uc
+        .get_feature("run", Some("repo1"))
+        .await
+        .expect("get_feature must not fail on cyclic graph")
+        .expect("feature should exist");
+
+    // Both A and B appear exactly once each.
+    let syms: Vec<&str> = feature.path.iter().map(|n| n.symbol.as_str()).collect();
+    let a_count = syms.iter().filter(|&&s| s == "A").count();
+    let b_count = syms.iter().filter(|&&s| s == "B").count();
+    assert_eq!(a_count, 1, "A must appear exactly once");
+    assert_eq!(b_count, 1, "B must appear exactly once");
+}
+
+/// A diamond dependency (A → B, A → C, B → D, C → D) must not duplicate D.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_diamond_dependency_no_duplicates() {
+    let cg = make_call_graph_use_case().await;
+    let refs = vec![
+        call_ref("main", "B", "src/main.rs", 1, "repo1"),
+        call_ref("main", "C", "src/main.rs", 2, "repo1"),
+        call_ref("B", "D", "src/b.rs", 5, "repo1"),
+        call_ref("C", "D", "src/c.rs", 5, "repo1"),
+    ];
+    cg.save_references(&refs).await.expect("seed failed");
+
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    let feature = uc
+        .get_feature("main", Some("repo1"))
+        .await
+        .expect("get_feature failed")
+        .expect("feature should exist");
+
+    let d_count = feature.path.iter().filter(|n| n.symbol == "D").count();
+    assert_eq!(d_count, 1, "D must appear exactly once (diamond dedup)");
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Criticality scoring
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// A feature touching a security-sensitive symbol scores higher criticality
+/// than an otherwise identical feature without security keywords.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_security_sensitive_raises_criticality() {
+    let cg = make_call_graph_use_case().await;
+    // Two entry points: one calls a security-sensitive symbol, the other doesn't.
+    let refs = vec![
+        // Secure path: main_secure → validate_password
+        call_ref(
+            "main_secure",
+            "validate_password",
+            "src/main.rs",
+            1,
+            "repo1",
+        ),
+        // Plain path: run_plain → compute_sum
+        call_ref("run_plain", "compute_sum", "src/runner.rs", 1, "repo1"),
+    ];
+    cg.save_references(&refs).await.expect("seed failed");
+
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    let features = uc
+        .list_features("repo1", 100)
+        .await
+        .expect("list_features failed");
+
+    let secure = features
+        .iter()
+        .find(|f| f.entry_point == "main_secure")
+        .expect("main_secure feature not found");
+    let plain = features
+        .iter()
+        .find(|f| f.entry_point == "run_plain")
+        .expect("run_plain feature not found");
+
+    assert!(
+        secure.criticality > plain.criticality,
+        "security-sensitive path should score higher: secure={}, plain={}",
+        secure.criticality,
+        plain.criticality
+    );
+}
+
+/// Criticality must always be in the range [0.0, 1.0].
+#[tokio::test(flavor = "multi_thread")]
+async fn test_criticality_is_within_bounds() {
+    let cg = make_call_graph_use_case().await;
+    // Seed a graph that exercises multiple scoring signals at once:
+    // deep chain + security keyword + multi-file spread.
+    let refs = vec![
+        call_ref("main", "auth_middleware", "src/main.rs", 1, "repo1"),
+        call_ref(
+            "auth_middleware",
+            "validate_token",
+            "src/auth.rs",
+            5,
+            "repo1",
+        ),
+        call_ref(
+            "validate_token",
+            "crypto_verify",
+            "src/crypto.rs",
+            10,
+            "repo1",
+        ),
+        call_ref(
+            "crypto_verify",
+            "permission_check",
+            "src/permissions.rs",
+            15,
+            "repo1",
+        ),
+    ];
+    cg.save_references(&refs).await.expect("seed failed");
+
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    let features = uc
+        .list_features("repo1", 100)
+        .await
+        .expect("list_features failed");
+
+    for f in &features {
+        assert!(
+            f.criticality >= 0.0 && f.criticality <= 1.0,
+            "criticality out of range for '{}': {}",
+            f.entry_point,
+            f.criticality
+        );
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// list_features
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// `list_features` returns an empty slice when the repository has no call-graph
+/// data at all.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_features_empty_repository() {
+    let cg = make_call_graph_use_case().await;
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    let features = uc
+        .list_features("nonexistent-repo", 100)
+        .await
+        .expect("list_features failed");
+
+    assert!(features.is_empty(), "expected empty list for empty repo");
+}
+
+/// Results are sorted by descending criticality.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_features_sorted_by_descending_criticality() {
+    let cg = make_call_graph_use_case().await;
+    // Two distinct entry points.
+    let refs = vec![
+        call_ref("main_auth", "authenticate_user", "src/main.rs", 1, "repo1"),
+        call_ref("run_job", "process_batch", "src/job.rs", 1, "repo1"),
+    ];
+    cg.save_references(&refs).await.expect("seed failed");
+
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    let features = uc
+        .list_features("repo1", 100)
+        .await
+        .expect("list_features failed");
+
+    // Verify descending order.
+    for window in features.windows(2) {
+        assert!(
+            window[0].criticality >= window[1].criticality,
+            "features not sorted: {} < {}",
+            window[0].criticality,
+            window[1].criticality
+        );
+    }
+}
+
+/// `limit` parameter must cap the number of returned features.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_features_respects_limit() {
+    let cg = make_call_graph_use_case().await;
+    // Three separate entry points.
+    let refs = vec![
+        call_ref("main", "a", "src/main.rs", 1, "repo1"),
+        call_ref("run", "b", "src/run.rs", 1, "repo1"),
+        call_ref("start", "c", "src/start.rs", 1, "repo1"),
+    ];
+    cg.save_references(&refs).await.expect("seed failed");
+
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    let features = uc
+        .list_features("repo1", 2)
+        .await
+        .expect("list_features failed");
+
+    assert!(
+        features.len() <= 2,
+        "limit=2 but got {} features",
+        features.len()
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// get_feature
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// `get_feature` returns `None` when the symbol does not exist in the call graph.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_feature_not_found() {
+    let cg = make_call_graph_use_case().await;
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    let result = uc
+        .get_feature("does_not_exist", None)
+        .await
+        .expect("get_feature must not error");
+    assert!(result.is_none(), "expected None for unknown symbol");
+}
+
+/// `get_feature` returns the feature with the correct entry_point when found.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_feature_found() {
+    let cg = make_call_graph_use_case().await;
+    let refs = vec![call_ref("main", "helper", "src/main.rs", 1, "repo1")];
+    cg.save_references(&refs).await.expect("seed failed");
+
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    let result = uc
+        .get_feature("main", Some("repo1"))
+        .await
+        .expect("get_feature failed");
+
+    let feature = result.expect("expected Some(feature) for 'main'");
+    assert_eq!(feature.entry_point, "main");
+    assert_eq!(feature.repository_id, "repo1");
+}
+
+/// The feature id must be a non-empty stable string derived from repository and entry point.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_feature_id_is_stable() {
+    let cg = make_call_graph_use_case().await;
+    let refs = vec![call_ref("main", "foo", "src/main.rs", 1, "repo1")];
+    cg.save_references(&refs).await.expect("seed failed");
+
+    let uc = ExecutionFeaturesUseCase::new(Arc::clone(&cg));
+    let f1 = uc
+        .get_feature("main", Some("repo1"))
+        .await
+        .expect("get_feature failed")
+        .expect("feature not found");
+
+    let uc2 = ExecutionFeaturesUseCase::new(cg);
+    let f2 = uc2
+        .get_feature("main", Some("repo1"))
+        .await
+        .expect("get_feature failed")
+        .expect("feature not found");
+
+    assert_eq!(f1.id, f2.id, "feature id must be stable across calls");
+    assert!(!f1.id.is_empty(), "feature id must not be empty");
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// get_affected_features
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// A feature whose call chain includes a changed symbol must be returned.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_affected_features_includes_matching_feature() {
+    let cg = make_call_graph_use_case().await;
+    // main → auth → session
+    let refs = vec![
+        call_ref("main", "auth", "src/main.rs", 1, "repo1"),
+        call_ref("auth", "session", "src/auth.rs", 5, "repo1"),
+    ];
+    cg.save_references(&refs).await.expect("seed failed");
+
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    let affected = uc
+        .get_affected_features(&["session".to_string()], Some("repo1"))
+        .await
+        .expect("get_affected_features failed");
+
+    assert!(
+        !affected.is_empty(),
+        "should find at least one affected feature"
+    );
+    let ep_names: Vec<&str> = affected.iter().map(|f| f.entry_point.as_str()).collect();
+    assert!(
+        ep_names.contains(&"main"),
+        "feature rooted at 'main' should be affected; got {:?}",
+        ep_names
+    );
+}
+
+/// A feature whose call chain does NOT include any changed symbol must be excluded.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_affected_features_excludes_unrelated_feature() {
+    let cg = make_call_graph_use_case().await;
+    // Two separate call chains.
+    let refs = vec![
+        call_ref("main", "auth", "src/main.rs", 1, "repo1"),
+        call_ref("run", "metrics", "src/run.rs", 1, "repo1"),
+    ];
+    cg.save_references(&refs).await.expect("seed failed");
+
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    // Only `metrics` changed — only the `run` chain should be affected.
+    let affected = uc
+        .get_affected_features(&["metrics".to_string()], Some("repo1"))
+        .await
+        .expect("get_affected_features failed");
+
+    let ep_names: Vec<&str> = affected.iter().map(|f| f.entry_point.as_str()).collect();
+    assert!(
+        !ep_names.contains(&"main"),
+        "'main' chain should NOT be affected; got {:?}",
+        ep_names
+    );
+    assert!(
+        ep_names.contains(&"run"),
+        "'run' chain should be affected; got {:?}",
+        ep_names
+    );
+}
+
+/// An empty `changed_symbols` slice must always return an empty result.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_affected_features_empty_input() {
+    let cg = make_call_graph_use_case().await;
+    let refs = vec![call_ref("main", "foo", "src/main.rs", 1, "repo1")];
+    cg.save_references(&refs).await.expect("seed failed");
+
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    let affected = uc
+        .get_affected_features(&[], Some("repo1"))
+        .await
+        .expect("get_affected_features failed");
+
+    assert!(
+        affected.is_empty(),
+        "empty changed_symbols should return empty result"
+    );
+}
+
+/// Affected features must be sorted by descending criticality.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_affected_features_sorted_by_criticality() {
+    let cg = make_call_graph_use_case().await;
+    // Two entry points that both call `shared_util`.
+    let refs = vec![
+        call_ref("main_auth", "validate_token", "src/main.rs", 1, "repo1"),
+        call_ref("validate_token", "shared_util", "src/auth.rs", 5, "repo1"),
+        call_ref("run_job", "shared_util", "src/job.rs", 1, "repo1"),
+    ];
+    cg.save_references(&refs).await.expect("seed failed");
+
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    let affected = uc
+        .get_affected_features(&["shared_util".to_string()], Some("repo1"))
+        .await
+        .expect("get_affected_features failed");
+
+    // Verify sorted by descending criticality.
+    for window in affected.windows(2) {
+        assert!(
+            window[0].criticality >= window[1].criticality,
+            "affected features not sorted: {} < {}",
+            window[0].criticality,
+            window[1].criticality
+        );
+    }
+}

--- a/tests/execution_features_tests.rs
+++ b/tests/execution_features_tests.rs
@@ -480,12 +480,12 @@ async fn test_feature_id_is_stable() {
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
-// get_affected_features
+// get_impacted_features
 // ──────────────────────────────────────────────────────────────────────────────
 
 /// A feature whose call chain includes a changed symbol must be returned.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_get_affected_features_includes_matching_feature() {
+async fn test_get_impacted_features_includes_matching_feature() {
     let cg = make_call_graph_use_case().await;
     // main → auth → session
     let refs = vec![
@@ -496,9 +496,9 @@ async fn test_get_affected_features_includes_matching_feature() {
 
     let uc = ExecutionFeaturesUseCase::new(cg);
     let affected = uc
-        .get_affected_features(&["session".to_string()], Some("repo1"))
+        .get_impacted_features(&["session".to_string()], Some("repo1"))
         .await
-        .expect("get_affected_features failed");
+        .expect("get_impacted_features failed");
 
     assert!(
         !affected.is_empty(),
@@ -514,7 +514,7 @@ async fn test_get_affected_features_includes_matching_feature() {
 
 /// A feature whose call chain does NOT include any changed symbol must be excluded.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_get_affected_features_excludes_unrelated_feature() {
+async fn test_get_impacted_features_excludes_unrelated_feature() {
     let cg = make_call_graph_use_case().await;
     // Two separate call chains.
     let refs = vec![
@@ -526,9 +526,9 @@ async fn test_get_affected_features_excludes_unrelated_feature() {
     let uc = ExecutionFeaturesUseCase::new(cg);
     // Only `metrics` changed — only the `run` chain should be affected.
     let affected = uc
-        .get_affected_features(&["metrics".to_string()], Some("repo1"))
+        .get_impacted_features(&["metrics".to_string()], Some("repo1"))
         .await
-        .expect("get_affected_features failed");
+        .expect("get_impacted_features failed");
 
     let ep_names: Vec<&str> = affected.iter().map(|f| f.entry_point.as_str()).collect();
     assert!(
@@ -545,16 +545,16 @@ async fn test_get_affected_features_excludes_unrelated_feature() {
 
 /// An empty `changed_symbols` slice must always return an empty result.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_get_affected_features_empty_input() {
+async fn test_get_impacted_features_empty_input() {
     let cg = make_call_graph_use_case().await;
     let refs = vec![call_ref("main", "foo", "src/main.rs", 1, "repo1")];
     cg.save_references(&refs).await.expect("seed failed");
 
     let uc = ExecutionFeaturesUseCase::new(cg);
     let affected = uc
-        .get_affected_features(&[], Some("repo1"))
+        .get_impacted_features(&[], Some("repo1"))
         .await
-        .expect("get_affected_features failed");
+        .expect("get_impacted_features failed");
 
     assert!(
         affected.is_empty(),
@@ -564,7 +564,7 @@ async fn test_get_affected_features_empty_input() {
 
 /// Affected features must be sorted by descending criticality.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_get_affected_features_sorted_by_criticality() {
+async fn test_get_impacted_features_sorted_by_criticality() {
     let cg = make_call_graph_use_case().await;
     // Two entry points that both call `shared_util`.
     let refs = vec![
@@ -576,9 +576,9 @@ async fn test_get_affected_features_sorted_by_criticality() {
 
     let uc = ExecutionFeaturesUseCase::new(cg);
     let affected = uc
-        .get_affected_features(&["shared_util".to_string()], Some("repo1"))
+        .get_impacted_features(&["shared_util".to_string()], Some("repo1"))
         .await
-        .expect("get_affected_features failed");
+        .expect("get_impacted_features failed");
 
     // Verify sorted by descending criticality.
     for window in affected.windows(2) {

--- a/tests/execution_features_tests.rs
+++ b/tests/execution_features_tests.rs
@@ -454,6 +454,26 @@ async fn test_get_feature_found() {
     assert_eq!(feature.repository_id, "repo1");
 }
 
+/// `get_feature` returns `None` when the symbol exists but is not an entry point
+/// (i.e. it has callers and its name does not match a known entry-point pattern).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_feature_non_entry_point_returns_none() {
+    let cg = make_call_graph_use_case().await;
+    // main → helper: 'helper' has a caller and is not a known entry-point name.
+    let refs = vec![call_ref("main", "helper", "src/main.rs", 1, "repo1")];
+    cg.save_references(&refs).await.expect("seed failed");
+
+    let uc = ExecutionFeaturesUseCase::new(cg);
+    let result = uc
+        .get_feature("helper", Some("repo1"))
+        .await
+        .expect("get_feature must not error");
+    assert!(
+        result.is_none(),
+        "non-entry-point 'helper' should return None"
+    );
+}
+
 /// The feature id must be a non-empty stable string derived from repository and entry point.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_feature_id_is_stable() {

--- a/tests/execution_features_tests.rs
+++ b/tests/execution_features_tests.rs
@@ -73,46 +73,6 @@ async fn test_zero_caller_symbol_is_entry_point() {
     );
 }
 
-/// A symbol whose short name matches a well-known pattern (e.g. `handle_request`)
-/// is flagged as an entry point even when it does have callers.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_well_known_name_is_entry_point_even_with_callers() {
-    let cg = make_call_graph_use_case().await;
-    // dispatcher calls handle_request, and handle_request calls process_data.
-    // handle_request HAS a caller (dispatcher) but its name matches the
-    // `handle_*` prefix pattern — it should still surface as an entry point.
-    let refs = vec![
-        call_ref(
-            "dispatcher",
-            "handle_request",
-            "src/dispatcher.rs",
-            10,
-            "repo1",
-        ),
-        call_ref(
-            "handle_request",
-            "process_data",
-            "src/handler.rs",
-            20,
-            "repo1",
-        ),
-    ];
-    cg.save_references(&refs).await.expect("seed failed");
-
-    let uc = ExecutionFeaturesUseCase::new(cg);
-    let features = uc
-        .list_features("repo1", 100)
-        .await
-        .expect("list_features failed");
-
-    let entry_points: Vec<&str> = features.iter().map(|f| f.entry_point.as_str()).collect();
-    assert!(
-        entry_points.contains(&"handle_request"),
-        "handle_request should be an entry point due to name pattern; got: {:?}",
-        entry_points
-    );
-}
-
 /// Symbols that only appear as callees (never as callers) are not entry points.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_pure_callee_is_not_entry_point() {
@@ -257,49 +217,6 @@ async fn test_diamond_dependency_no_duplicates() {
 // ──────────────────────────────────────────────────────────────────────────────
 // Criticality scoring
 // ──────────────────────────────────────────────────────────────────────────────
-
-/// A feature touching a security-sensitive symbol scores higher criticality
-/// than an otherwise identical feature without security keywords.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_security_sensitive_raises_criticality() {
-    let cg = make_call_graph_use_case().await;
-    // Two entry points: one calls a security-sensitive symbol, the other doesn't.
-    let refs = vec![
-        // Secure path: main_secure → validate_password
-        call_ref(
-            "main_secure",
-            "validate_password",
-            "src/main.rs",
-            1,
-            "repo1",
-        ),
-        // Plain path: run_plain → compute_sum
-        call_ref("run_plain", "compute_sum", "src/runner.rs", 1, "repo1"),
-    ];
-    cg.save_references(&refs).await.expect("seed failed");
-
-    let uc = ExecutionFeaturesUseCase::new(cg);
-    let features = uc
-        .list_features("repo1", 100)
-        .await
-        .expect("list_features failed");
-
-    let secure = features
-        .iter()
-        .find(|f| f.entry_point == "main_secure")
-        .expect("main_secure feature not found");
-    let plain = features
-        .iter()
-        .find(|f| f.entry_point == "run_plain")
-        .expect("run_plain feature not found");
-
-    assert!(
-        secure.criticality > plain.criticality,
-        "security-sensitive path should score higher: secure={}, plain={}",
-        secure.criticality,
-        plain.criticality
-    );
-}
 
 /// Criticality must always be in the range [0.0, 1.0].
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Introduces forward call-chain analysis rooted at entry-point symbols,
complementing the existing upward ImpactAnalysisUseCase.

New domain models (src/domain/models/execution_feature.rs):
- FeatureNode: single node in a forward BFS call chain (symbol, file,
  line, depth, repository_id)
- ExecutionFeature: full feature record with id, name, entry_point,
  path, depth, file_count, and a 0.0–1.0 criticality score

New use case (src/application/use_cases/execution_features.rs):
- Entry-point detection: symbols with zero callers, or whose short name
  matches well-known patterns (main, run, start, init, handle, execute,
  process, test_*, it_*, handle_*, on_*)
- Forward BFS with cycle detection via visited HashSet (mirrors the
  pattern used by ImpactAnalysisUseCase and SymbolContextUseCase)
- Criticality scoring — five weighted signals summed and clamped to 1.0:
    file spread (0.30), security sensitivity (0.25), external calls
    (0.20), test coverage gap (0.15), BFS depth (0.10)
- Public API: list_features, get_feature, get_affected_features

CLI additions (src/cli/mod.rs):
- FeaturesSubcommand enum with list, get, and affected subcommands
- Features { subcommand } variant added to Commands

Wiring:
- Container::execution_features_use_case() factory method
- ExecutionFeaturesController with text/json/vimgrep formatters
- Router matches Commands::Features and delegates to controller
- Features added to read_only set in main.rs (no writes needed)

https://claude.ai/code/session_01CZpnvUWc3brSbRpDJfByrB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added execution‑features analysis: list top entry‑point features for a repository, fetch feature details by symbol (includes call‑chain path with file/line, depth, file count, stable id), and find features impacted by changed symbols. Features are ranked by a normalized criticality score in [0.0,1.0].

* **CLI / UX**
  * New "features" subcommands (list/get/impacted) with JSON, vimgrep, and human‑readable text outputs; treated as read‑only.

* **Tests**
  * Added comprehensive async test suite covering entry‑point detection, traversal, deduplication, ordering, scoring, and limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->