### PR TITLE
Real Leiden + symbol-level community detection (plus clustering/call-graph fixes)

### DIFF
--- a/.claude/skills/codesearch/SKILL.md
+++ b/.claude/skills/codesearch/SKILL.md
@@ -23,6 +23,7 @@ Invoke this skill **immediately** when:
 - User asks **who calls** a function or **what does a function call** (symbol context)
 - User asks for an **explanation** of a symbol's full call flow or business purpose (`explain`)
 - User asks about the **architectural structure** of a repo — modules, clusters, entry-point features
+- User asks which **symbols form a feature/community** together, or which community a symbol belongs to (`symbol-clusters`)
 - User asks **which files one repository uses** from another (cross-repo dependencies)
 
 ## When to Use Built-in Tools Instead
@@ -193,6 +194,9 @@ codesearch features impacted authenticate hash_password
 
 ### Clusters — architectural modules (Leiden community detection)
 
+Runs Leiden community detection over the **file** dependency graph to find
+tightly-coupled groups of files (architectural modules).
+
 ```shell
 # List tightly-coupled file clusters (architectural modules)
 codesearch clusters list my-repo
@@ -203,6 +207,31 @@ codesearch clusters get src/api/auth.rs my-repo
 # Print a high-level Markdown architecture overview table
 codesearch clusters overview my-repo
 ```
+
+### Symbol Clusters — behavioural communities (Leiden over the call graph)
+
+The same Leiden algorithm one level finer: it clusters the **symbol** call graph
+(functions, methods, types) instead of files, so the communities are
+behavioural units — a feature, a subsystem, a collaborating set of functions —
+that frequently cut across file boundaries. Use file-level `clusters` to answer
+"what are this repo's modules?"; use `symbol-clusters` to answer "which symbols
+form a feature together, regardless of where they live?".
+
+```shell
+# List symbol communities (size, dominant language, cohesion, sample members)
+codesearch symbol-clusters list my-repo
+
+# Which community does a given symbol belong to?
+# Resolves by exact fully-qualified name, then short-name suffix, then substring.
+codesearch symbol-clusters get authenticate my-repo
+codesearch symbol-clusters get "MyNs/Auth#authenticate()." my-repo
+
+# JSON output for scripting (both subcommands; vimgrep is not supported)
+codesearch symbol-clusters list my-repo --format json
+```
+
+Requires the repository to have been indexed with call-graph support (the
+default). When the call graph is empty, the list is empty.
 
 ### Uses — cross-repository file dependencies
 
@@ -276,4 +305,4 @@ codesearch --no-rerank search "query"
 
 ## Keywords
 
-semantic search, hybrid search, code search, natural language search, find code, explore codebase, code understanding, intent search, AST analysis, embeddings, code discovery, code exploration, BM25, keyword search, RRF, reciprocal rank fusion, call graph, impact analysis, blast radius, symbol context, callers, callees, dependency analysis, explain, call flow, execution features, criticality, clusters, architecture overview, Leiden, module detection, cross-repository dependencies, uses, regex symbol match
+semantic search, hybrid search, code search, natural language search, find code, explore codebase, code understanding, intent search, AST analysis, embeddings, code discovery, code exploration, BM25, keyword search, RRF, reciprocal rank fusion, call graph, impact analysis, blast radius, symbol context, callers, callees, dependency analysis, explain, call flow, execution features, criticality, clusters, architecture overview, Leiden, module detection, symbol clusters, symbol communities, community detection, cross-repository dependencies, uses, regex symbol match

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,7 @@ Or after copying the release binary to your `$PATH`:
 ```bash
 codesearch index .
 codesearch search "embedding similarity"
-codesearch impact MyStruct --depth 5
+codesearch impact MyStruct
 codesearch context some_function
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,8 @@ The codebase follows **Domain-Driven Design (DDD)** with a strict **Ports & Adap
 | Call graph extraction & relationship queries | `src/application/use_cases/call_graph.rs` |
 | LLM explanation of a symbol's call flow | `src/application/use_cases/explain.rs` |
 | Execution features + criticality scoring | `src/application/use_cases/execution_features.rs` |
-| Architectural cluster detection (Leiden) | `src/application/use_cases/cluster_detection.rs` |
+| Architectural (file-level) cluster detection (Leiden) | `src/application/use_cases/cluster_detection.rs` |
+| Symbol-level community detection (Leiden over the call graph) | `src/application/use_cases/symbol_cluster_detection.rs` |
 | File / cross-repo relationship graph (`uses`) | `src/application/use_cases/file_relationship.rs` |
 | Source snippet lookup | `src/application/use_cases/snippet_lookup.rs` |
 | List / delete repositories | `src/application/use_cases/{list,delete}_repository.rs` |

--- a/README.md
+++ b/README.md
@@ -294,6 +294,23 @@ codesearch clusters get src/api/auth.rs my-repo
 codesearch clusters overview my-repo
 ```
 
+### Symbol Clusters (`symbol-clusters`)
+
+Runs the same Leiden algorithm over the **symbol** call graph instead of files,
+grouping individual functions, methods, and types into behavioural communities
+that often cut across file boundaries.
+
+```bash
+# List detected symbol communities
+codesearch symbol-clusters list my-repo
+
+# Find which community a symbol belongs to (exact, short-name, or substring)
+codesearch symbol-clusters get authenticate my-repo
+
+# JSON output (vimgrep is not supported for either subcommand)
+codesearch symbol-clusters list my-repo --format json
+```
+
 ### Cross-repository Usage (`uses`)
 
 Lists every file in one repository that references symbols defined in another,
@@ -396,6 +413,8 @@ The HTTP server exposes the MCP endpoint at `/mcp`.
 | `list_clusters` | Architectural clusters via Leiden community detection. Accepts `repository_id`. |
 | `get_file_cluster` | The cluster a given file belongs to. Accepts `file_path` and `repository_id`. |
 | `architecture_overview` | Markdown table summarising clusters and inter-cluster dependencies. Accepts `repository_id`. |
+| `list_symbol_clusters` | Symbol-level communities via Leiden over the call graph. Accepts `repository_id`. |
+| `get_symbol_cluster` | The symbol community a given symbol belongs to. Accepts `symbol` and `repository_id`. |
 
 The `query_graph` tool supports eight intention-named relationship `pattern`s, returning
 only the requested edge type instead of every relationship at once:

--- a/docs/features/architecture-analysis.md
+++ b/docs/features/architecture-analysis.md
@@ -126,6 +126,66 @@ Clusters for `my-repo` — 3 clusters, 42 files, 118 edges
 File `src/api/auth.rs` belongs to cluster `auth` (8 files, rust, cohesion 0.82)
 ```
 
+## Symbol Communities (`codesearch symbol-clusters`)
+
+`symbol-clusters` runs the **same Leiden algorithm one level finer** — over the
+symbol call graph (`symbol_references`) rather than the file-dependency graph.
+Nodes are individual symbols (functions, methods, types) and edges are
+caller→callee references weighted by reference kind. The resulting communities
+are *behavioural* units — a feature, a subsystem, a collaborating set of
+functions — that frequently cut across file and directory boundaries, which the
+file-level `clusters` view cannot show.
+
+Use `clusters` to answer "what are this repo's modules?" and `symbol-clusters`
+to answer "which symbols form a feature together, regardless of where they live?".
+
+### Subcommands
+
+```bash
+# List all symbol communities detected in the repository
+codesearch symbol-clusters list my-repo
+
+# JSON output
+codesearch symbol-clusters list my-repo --format json
+
+# Show which community a symbol belongs to. The symbol is resolved by exact
+# fully-qualified name, then short-name suffix, then substring (case-sensitive).
+codesearch symbol-clusters get authenticate my-repo
+codesearch symbol-clusters get "MyNs/Auth#authenticate()." my-repo
+```
+
+### Options
+
+| Flag | Subcommand | Default | Description |
+|------|------------|---------|-------------|
+| `-F, --format` | `list`, `get` | `text` | Output format: `text` or `json` (vimgrep is not supported) |
+
+Requires the repository to have been indexed with call-graph support (the
+default). When the call graph is empty, no communities are returned.
+
+### Example: `symbol-clusters list`
+
+```text
+Symbol communities for `my-repo` — 5 communities, 214 symbols, 087 edges
+────────────────────────────────────────────────────────────
+  1. authenticate (18 symbols, rust, cohesion 0.71)
+      MyNs/Auth#authenticate().
+      MyNs/Auth#verify_password().
+      MyNs/Session#issue_token().
+      … and 15 more
+  2. indexing (24 symbols, rust, cohesion 0.66)
+      …
+```
+
+### Example: `symbol-clusters get`
+
+```text
+Symbol `authenticate` belongs to community `authenticate` (18 symbols, rust, cohesion 0.71)
+    MyNs/Auth#authenticate().
+    MyNs/Auth#verify_password().
+    …
+```
+
 ## Cross-repository Usage (`codesearch uses`)
 
 `codesearch uses <from> <to>` lists every file in the `<from>` repository that

--- a/src/application/use_cases/cluster_detection.rs
+++ b/src/application/use_cases/cluster_detection.rs
@@ -278,21 +278,22 @@ fn leiden_core(graph: &Graph) -> Vec<usize> {
         let mut refined = refine_partition(&current, &partition, &mut rng);
         renumber(&mut refined);
 
-        // Aggregate by the refined partition; `super_of[node]` is the new
-        // super-node index for each current node.
-        let (aggregated, super_of) = aggregate_by(&current, &refined);
+        // Aggregate by the refined partition. The renumbered `refined` vector is
+        // itself the current-node → super-node map (sub-community i becomes
+        // super-node i), so there is no separate mapping to return.
+        let aggregated = aggregate_by(&current, &refined);
 
         // Seed the next level's partition from the *unrefined* community: every
         // refined sub-community (now a super-node) inherits the community it was
         // refined out of, so local moving resumes from the coarse structure.
         let mut next_partition = vec![0usize; aggregated.n];
         for node in 0..current.n {
-            next_partition[super_of[node]] = partition[node];
+            next_partition[refined[node]] = partition[node];
         }
 
         // Compose the original→super mapping through this aggregation.
         for slot in node_to_super.iter_mut() {
-            *slot = super_of[*slot];
+            *slot = refined[*slot];
         }
 
         current = aggregated;
@@ -302,6 +303,23 @@ fn leiden_core(graph: &Graph) -> Vec<usize> {
     (0..graph.n)
         .map(|node| partition[node_to_super[node]])
         .collect()
+}
+
+/// Group node indices by their partition label, in ascending (label, node)
+/// order. The deterministic ordering is what lets the post-passes split
+/// communities the same way on every run.
+fn group_by_label(partition: &[usize]) -> BTreeMap<usize, Vec<usize>> {
+    let mut by_label: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    for (node, &label) in partition.iter().enumerate() {
+        by_label.entry(label).or_default().push(node);
+    }
+    by_label
+}
+
+/// First label not currently in use — the starting point for handing out fresh
+/// labels to the pieces a post-pass splits off.
+fn first_free_label(partition: &[usize]) -> usize {
+    partition.iter().copied().max().unwrap_or(0) + 1
 }
 
 /// Enforce Leiden's defining guarantee: every community is a single connected
@@ -316,14 +334,9 @@ fn enforce_connectivity(graph: &Graph, partition: &mut [usize]) {
     if graph.n == 0 {
         return;
     }
-    let mut next_label = partition.iter().copied().max().unwrap_or(0) + 1;
+    let mut next_label = first_free_label(partition);
 
-    let mut nodes_by_label: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
-    for (node, &label) in partition.iter().enumerate() {
-        nodes_by_label.entry(label).or_default().push(node);
-    }
-
-    for (_label, nodes) in nodes_by_label {
+    for (_label, nodes) in group_by_label(partition) {
         let members: HashSet<usize> = nodes.iter().copied().collect();
         let mut visited: HashSet<usize> = HashSet::new();
         let mut first_component = true;
@@ -369,14 +382,9 @@ fn split_oversized(graph: &Graph, partition: &mut [usize]) {
         return;
     }
     let max_size = (graph.n as f64 * MAX_COMMUNITY_FRACTION).ceil() as usize;
-    let mut next_label = partition.iter().copied().max().unwrap_or(0) + 1;
+    let mut next_label = first_free_label(partition);
 
-    let mut nodes_by_label: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
-    for (node, &label) in partition.iter().enumerate() {
-        nodes_by_label.entry(label).or_default().push(node);
-    }
-
-    for (_label, nodes) in nodes_by_label {
+    for (_label, nodes) in group_by_label(partition) {
         if nodes.len() < MIN_SPLIT_SIZE || nodes.len() <= max_size {
             continue;
         }
@@ -631,14 +639,13 @@ fn renumber(partition: &mut Vec<usize>) {
 }
 
 /// Aggregate `graph` by collapsing each group in `membership` (assumed
-/// contiguous `0..k`) into a single super-node.
+/// contiguous `0..k`) into a single super-node, returning the aggregated graph.
 ///
-/// Returns the aggregated graph together with `super_of`, where
-/// `super_of[node]` is the super-node index of each original node (== its
-/// `membership`). Intra-group edges and each node's existing self-loop mass are
-/// carried forward as the super-node's self-loop, so total edge weight is
-/// conserved across aggregation levels.
-fn aggregate_by(graph: &Graph, membership: &[usize]) -> (Graph, Vec<usize>) {
+/// `membership` doubles as the node → super-node map (node `i` collapses into
+/// super-node `membership[i]`), so it is not returned. Intra-group edges and
+/// each node's existing self-loop mass are carried forward as the super-node's
+/// self-loop, so total edge weight is conserved across aggregation levels.
+fn aggregate_by(graph: &Graph, membership: &[usize]) -> Graph {
     let num = membership.iter().copied().max().map(|m| m + 1).unwrap_or(0);
     let mut new_graph = Graph::new(num);
 
@@ -674,7 +681,7 @@ fn aggregate_by(graph: &Graph, membership: &[usize]) -> (Graph, Vec<usize>) {
         new_graph.add_self_loop(node, w);
     }
 
-    (new_graph, membership.to_vec())
+    new_graph
 }
 
 // ── Cluster naming ────────────────────────────────────────────────────────

--- a/src/application/use_cases/cluster_detection.rs
+++ b/src/application/use_cases/cluster_detection.rs
@@ -474,8 +474,10 @@ fn local_moving_phase(graph: &Graph, partition: &mut Vec<usize>) {
     }
 
     let mut improved = true;
-    while improved {
+    let mut iters = 0usize;
+    while improved && iters < MAX_ITERATIONS {
         improved = false;
+        iters += 1;
         for u in 0..graph.n {
             let cu = partition[u];
             let ku = graph.degree[u];

--- a/src/application/use_cases/cluster_detection.rs
+++ b/src/application/use_cases/cluster_detection.rs
@@ -3,17 +3,29 @@
 //! The algorithm follows Traag et al. (2019):
 //!   1. **Local moving** — each node greedily moves to the neighbour partition
 //!      that maximises modularity gain.
-//!   2. **Refinement** — nodes are allowed to move to a random subset of
-//!      neighbouring partitions, escaping local optima and guaranteeing
-//!      internally-connected clusters.
+//!   2. **Refinement** — a second greedy pass that lets nodes escape the local
+//!      optimum the moving phase settled into.
 //!   3. **Aggregation** — each partition is collapsed into a super-node and
 //!      the procedure repeats until the modularity gain is below `1e-6` or
 //!      50 iterations have elapsed.
 //!
+//! The moving/refinement passes are modularity-greedy (Louvain-style) and do
+//! **not** by themselves guarantee that a community is internally connected —
+//! the defect Leiden was designed to fix. That guarantee is enforced explicitly
+//! as a post-pass ([`enforce_connectivity`]): any community that is not a single
+//! connected component in the induced subgraph is split into its components.
+//! A second post-pass ([`split_oversized`]) subdivides any community that grows
+//! to dominate the graph, so one mega-cluster cannot swallow the codebase.
+//!
+//! All phases are deterministic: candidate clusters are visited in a stable
+//! order and graphs are built from sorted edge lists, so the same input always
+//! yields the same partition (cluster *membership*; the opaque UUIDs assigned to
+//! each cluster are not stable and carry no ordering meaning).
+//!
 //! Edge weights are differentiated by reference kind (see `kind_weight`) so
 //! the algorithm clusters files that share strong semantic bonds.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -59,9 +71,12 @@ fn composite_weight(edge: &FileEdge) -> f64 {
     if edge.reference_kinds.is_empty() {
         return base * DEFAULT_KIND_WEIGHT;
     }
-    let mean_kind: f64 =
-        edge.reference_kinds.iter().map(|k| kind_weight(k)).sum::<f64>()
-            / edge.reference_kinds.len() as f64;
+    let mean_kind: f64 = edge
+        .reference_kinds
+        .iter()
+        .map(|k| kind_weight(k))
+        .sum::<f64>()
+        / edge.reference_kinds.len() as f64;
     base * mean_kind
 }
 
@@ -110,9 +125,42 @@ impl Graph {
 const MAX_ITERATIONS: usize = 50;
 const MIN_MODULARITY_GAIN: f64 = 1e-6;
 
+/// Communities larger than this fraction of the graph are subdivided by
+/// [`split_oversized`] so a single mega-cluster cannot dominate the output.
+const MAX_COMMUNITY_FRACTION: f64 = 0.25;
+/// A community is only considered for [`split_oversized`] when it has at least
+/// this many nodes — below it the size dominance is not meaningful.
+const MIN_SPLIT_SIZE: usize = 10;
+
 /// Run Leiden cluster detection on `graph` and return a partition: a
 /// `Vec<usize>` where `partition[node_index]` is the cluster id.
+///
+/// This is the modularity-greedy core ([`leiden_core`]) followed by the two
+/// guarantee-enforcing post-passes ([`enforce_connectivity`] then
+/// [`split_oversized`]); labels are renumbered contiguously at the end.
 fn leiden(graph: &Graph) -> Vec<usize> {
+    if graph.n == 0 {
+        return Vec::new();
+    }
+
+    let mut result = leiden_core(graph);
+    // Split any community that dominates the graph (uses the bare core on the
+    // induced subgraph, so this does not recurse through the post-passes).
+    split_oversized(graph, &mut result);
+    // Guarantee every final community is internally connected. Run last so that
+    // pieces produced by the oversized split are also connectivity-checked.
+    enforce_connectivity(graph, &mut result);
+    renumber(&mut result);
+    result
+}
+
+/// The bare modularity-greedy algorithm (local moving + refinement +
+/// aggregation), returning a partition mapped back to the original nodes. The
+/// labels are **not** renumbered and the connectivity / oversized guarantees are
+/// **not** enforced here — that is [`leiden`]'s job. Kept separate so the
+/// oversized-split post-pass can re-cluster a subgraph without re-triggering the
+/// post-passes (which would recurse indefinitely on an indivisible blob).
+fn leiden_core(graph: &Graph) -> Vec<usize> {
     if graph.n == 0 {
         return Vec::new();
     }
@@ -147,17 +195,130 @@ fn leiden(graph: &Graph) -> Vec<usize> {
     }
 
     // Map back to original nodes.
-    let final_partition: Vec<usize> = (0..graph.n)
+    (0..graph.n)
         .map(|node| {
             let supernode = node_to_supernode[node];
             partition[supernode]
         })
-        .collect();
+        .collect()
+}
 
-    // Renumber clusters 0..k contiguously.
-    let mut result = final_partition;
-    renumber(&mut result);
-    result
+/// Enforce Leiden's defining guarantee: every community is a single connected
+/// component of the induced subgraph. Any community that is split across two or
+/// more components (which the Louvain-style moving/refinement passes can
+/// produce) is broken apart — the first component keeps the original label and
+/// each subsequent component receives a fresh label.
+///
+/// Deterministic: communities are visited in ascending label order and nodes in
+/// ascending index order, so the same partition always splits the same way.
+fn enforce_connectivity(graph: &Graph, partition: &mut [usize]) {
+    if graph.n == 0 {
+        return;
+    }
+    let mut next_label = partition.iter().copied().max().unwrap_or(0) + 1;
+
+    let mut nodes_by_label: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    for (node, &label) in partition.iter().enumerate() {
+        nodes_by_label.entry(label).or_default().push(node);
+    }
+
+    for (_label, nodes) in nodes_by_label {
+        let members: HashSet<usize> = nodes.iter().copied().collect();
+        let mut visited: HashSet<usize> = HashSet::new();
+        let mut first_component = true;
+
+        for &start in &nodes {
+            if !visited.insert(start) {
+                continue;
+            }
+            // Collect the connected component containing `start`, restricted to
+            // nodes that share this community.
+            let mut component = vec![start];
+            let mut stack = vec![start];
+            while let Some(u) = stack.pop() {
+                for &(v, _) in &graph.adj[u] {
+                    if members.contains(&v) && visited.insert(v) {
+                        component.push(v);
+                        stack.push(v);
+                    }
+                }
+            }
+
+            if first_component {
+                // Leave the original label in place for the first component.
+                first_component = false;
+            } else {
+                let label = next_label;
+                next_label += 1;
+                for node in component {
+                    partition[node] = label;
+                }
+            }
+        }
+    }
+}
+
+/// Subdivide any community whose size exceeds [`MAX_COMMUNITY_FRACTION`] of the
+/// graph (and is at least [`MIN_SPLIT_SIZE`] nodes) by re-running [`leiden_core`]
+/// on its induced subgraph. The first resulting sub-community keeps the original
+/// label; the rest receive fresh labels. Single-level only: if the subgraph is
+/// indivisible the community is left as-is.
+fn split_oversized(graph: &Graph, partition: &mut [usize]) {
+    if graph.n == 0 {
+        return;
+    }
+    let max_size = (graph.n as f64 * MAX_COMMUNITY_FRACTION).ceil() as usize;
+    let mut next_label = partition.iter().copied().max().unwrap_or(0) + 1;
+
+    let mut nodes_by_label: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    for (node, &label) in partition.iter().enumerate() {
+        nodes_by_label.entry(label).or_default().push(node);
+    }
+
+    for (_label, nodes) in nodes_by_label {
+        if nodes.len() < MIN_SPLIT_SIZE || nodes.len() <= max_size {
+            continue;
+        }
+
+        // Build the induced subgraph: global node id → local index (nodes are
+        // already in ascending order, keeping local indices deterministic).
+        let local_of: HashMap<usize, usize> =
+            nodes.iter().enumerate().map(|(i, &g)| (g, i)).collect();
+        let mut sub = Graph::new(nodes.len());
+        for &gu in &nodes {
+            let lu = local_of[&gu];
+            for &(gv, w) in &graph.adj[gu] {
+                // Add each intra-community edge once (gu < gv).
+                if gu < gv {
+                    if let Some(&lv) = local_of.get(&gv) {
+                        sub.add_edge(lu, lv, w);
+                    }
+                }
+            }
+        }
+
+        let mut sub_partition = leiden_core(&sub);
+        renumber(&mut sub_partition);
+        let sub_clusters = sub_partition
+            .iter()
+            .copied()
+            .max()
+            .map(|m| m + 1)
+            .unwrap_or(0);
+        if sub_clusters <= 1 {
+            // Indivisible — leave the community intact.
+            continue;
+        }
+
+        // Sub-cluster 0 keeps the original label; the rest get fresh labels.
+        for (i, &gnode) in nodes.iter().enumerate() {
+            let sc = sub_partition[i];
+            if sc != 0 {
+                partition[gnode] = next_label + sc - 1;
+            }
+        }
+        next_label += sub_clusters - 1;
+    }
 }
 
 /// Modularity Q = (1/2m) Σ_ij [ A_ij - k_i k_j / 2m ] δ(c_i, c_j)
@@ -227,11 +388,19 @@ fn local_moving_phase(graph: &Graph, partition: &mut Vec<usize>) {
             let sigma_cu = *cluster_total.get(&cu).unwrap_or(&0.0);
             let remove_gain = ku_in - ku * (sigma_cu - ku) / m2;
 
-            // Find best target cluster.
+            // Find best target cluster. Iterate candidates in ascending cluster
+            // id (not HashMap order) so that ties — equal modularity gain — are
+            // broken deterministically; Rust's HashMap reseeds every process, so
+            // iterating it directly would make the final partition vary run to
+            // run on identical input.
+            let mut candidates: Vec<(usize, f64)> =
+                neighbour_weights.iter().map(|(&ct, &w)| (ct, w)).collect();
+            candidates.sort_unstable_by_key(|&(ct, _)| ct);
+
             let mut best_cluster = cu;
             let mut best_gain = 0.0;
 
-            for (&ct, &w_to_ct) in &neighbour_weights {
+            for (ct, w_to_ct) in candidates {
                 let sigma_ct = *cluster_total.get(&ct).unwrap_or(&0.0);
                 let gain = w_to_ct - ku * sigma_ct / m2 + remove_gain;
                 if gain > best_gain {
@@ -251,13 +420,15 @@ fn local_moving_phase(graph: &Graph, partition: &mut Vec<usize>) {
     }
 }
 
-/// Refinement phase: allow nodes to move to a random subset of neighbouring
-/// clusters.  This helps ensure clusters are internally connected and can
-/// escape local optima that local moving gets stuck in.
+/// Refinement phase: a second greedy pass that lets nodes escape the local
+/// optimum the moving phase settled into. For each node we take the first
+/// neighbouring cluster (in ascending id order) that yields a positive
+/// modularity gain. We iterate once over all nodes to keep runtime bounded.
 ///
-/// Implementation: for each node, if moving to a randomly-selected neighbour
-/// cluster yields a positive modularity gain, apply it.  We iterate once
-/// over all nodes (single pass to keep runtime bounded).
+/// Note: this pass does **not** guarantee internally-connected communities —
+/// that is enforced separately by [`enforce_connectivity`] after the algorithm
+/// converges. The candidate order is deterministic so the partition is stable
+/// across runs.
 fn refine_phase(graph: &Graph, partition: &mut Vec<usize>) {
     let m2 = 2.0 * graph.total_weight;
     if m2 == 0.0 {
@@ -359,11 +530,15 @@ fn aggregate_partition(graph: &Graph, partition: &[usize]) -> (Graph, Vec<usize>
         }
     }
 
-    // Add aggregated edges to new graph.
+    // Add aggregated edges to new graph in a deterministic order (HashMap
+    // iteration order is process-randomised, and adjacency-list ordering feeds
+    // back into later phases, so sort the collapsed edges before inserting).
     // Self-loops (u == v) must contribute to total_weight and degree but must
     // NOT appear in adj — movement decisions only involve distinct neighbours,
     // and a self-loop would create a spurious neighbour entry for a node.
-    for ((u, v), w) in edge_weights {
+    let mut aggregated: Vec<((usize, usize), f64)> = edge_weights.into_iter().collect();
+    aggregated.sort_unstable_by_key(|&((u, v), _)| (u, v));
+    for ((u, v), w) in aggregated {
         if u == v {
             new_graph.total_weight += w;
             new_graph.degree[u] += 2.0 * w; // both endpoints collapse to the same super-node
@@ -383,8 +558,8 @@ fn aggregate_partition(graph: &Graph, partition: &[usize]) -> (Graph, Vec<usize>
 
 /// Common words excluded when extracting meaningful keywords from symbol names.
 const STOP_WORDS: &[&str] = &[
-    "get", "set", "test", "new", "is", "has", "to", "from", "with", "the",
-    "and", "or", "of", "in", "at", "by", "for",
+    "get", "set", "test", "new", "is", "has", "to", "from", "with", "the", "and", "or", "of", "in",
+    "at", "by", "for",
 ];
 
 /// Derive a human-readable name for a cluster given its member file paths and
@@ -601,11 +776,14 @@ impl ClusterDetectionUseCase {
                 for edge in &graph.edges {
                     if edge.from_file == edge.to_file {
                         // Self-edge: internal to the singleton.
-                        map.entry(edge.from_file.clone()).and_modify(|(int, _)| *int += 1);
+                        map.entry(edge.from_file.clone())
+                            .and_modify(|(int, _)| *int += 1);
                     } else {
                         // External edge.
-                        map.entry(edge.from_file.clone()).and_modify(|(_, ext)| *ext += 1);
-                        map.entry(edge.to_file.clone()).and_modify(|(_, ext)| *ext += 1);
+                        map.entry(edge.from_file.clone())
+                            .and_modify(|(_, ext)| *ext += 1);
+                        map.entry(edge.to_file.clone())
+                            .and_modify(|(_, ext)| *ext += 1);
                     }
                 }
                 map
@@ -614,8 +792,7 @@ impl ClusterDetectionUseCase {
             let clusters: Vec<Cluster> = files
                 .iter()
                 .map(|path| {
-                    let lang =
-                        Language::from_path(Path::new(path)).as_str().to_string();
+                    let lang = Language::from_path(Path::new(path)).as_str().to_string();
                     let (int_e, ext_e) = file_to_edges.get(path).copied().unwrap_or((0, 0));
                     let cohesion = if int_e + ext_e == 0 {
                         0.0_f32
@@ -656,8 +833,12 @@ impl ClusterDetectionUseCase {
         // Track which (u,v) pairs have already been added.
         let mut added: HashMap<(usize, usize), f64> = HashMap::new();
         for edge in &graph.edges {
-            let Some(&u) = file_index.get(&edge.from_file) else { continue };
-            let Some(&v) = file_index.get(&edge.to_file) else { continue };
+            let Some(&u) = file_index.get(&edge.from_file) else {
+                continue;
+            };
+            let Some(&v) = file_index.get(&edge.to_file) else {
+                continue;
+            };
             if u == v {
                 continue;
             }
@@ -665,7 +846,11 @@ impl ClusterDetectionUseCase {
             let w = composite_weight(edge);
             *added.entry((lo, hi)).or_insert(0.0) += w;
         }
-        for ((u, v), w) in added {
+        // Insert edges in a deterministic order: adjacency-list ordering feeds
+        // into the clustering phases, so HashMap iteration order must not leak in.
+        let mut added_edges: Vec<((usize, usize), f64)> = added.into_iter().collect();
+        added_edges.sort_unstable_by_key(|&((u, v), _)| (u, v));
+        for ((u, v), w) in added_edges {
             g.add_edge(u, v, w);
         }
 
@@ -694,8 +879,7 @@ impl ClusterDetectionUseCase {
             .map(|_| Uuid::new_v4().to_string())
             .collect();
 
-        let cohesion_stats =
-            batch_cohesion(&file_to_cluster, &graph.edges, &cluster_ids);
+        let cohesion_stats = batch_cohesion(&file_to_cluster, &graph.edges, &cluster_ids);
 
         // Build a simple file→first_symbol map from edge symbols for naming.
         let mut file_symbol_map: HashMap<String, String> = HashMap::new();
@@ -728,10 +912,7 @@ impl ClusterDetectionUseCase {
                     .to_string();
 
                 // Cohesion.
-                let (int_e, ext_e) = cohesion_stats
-                    .get(&cid)
-                    .copied()
-                    .unwrap_or((0, 0));
+                let (int_e, ext_e) = cohesion_stats.get(&cid).copied().unwrap_or((0, 0));
                 let cohesion = if int_e + ext_e == 0 {
                     0.0_f32
                 } else {
@@ -768,10 +949,7 @@ impl ClusterDetectionUseCase {
     }
 
     /// Detect clusters in the dependency graph of `repository_id`.
-    pub async fn create_clusters(
-        &self,
-        repository_id: &str,
-    ) -> Result<ClusterGraph, DomainError> {
+    pub async fn create_clusters(&self, repository_id: &str) -> Result<ClusterGraph, DomainError> {
         Ok(self.create_clusters_with_graph(repository_id).await?.0)
     }
 
@@ -795,10 +973,7 @@ impl ClusterDetectionUseCase {
     ///
     /// One row per cluster: name, file count, dominant language, and the top 3
     /// outgoing inter-cluster dependencies by summed edge weight.
-    pub async fn architecture_overview(
-        &self,
-        repository_id: &str,
-    ) -> Result<String, DomainError> {
+    pub async fn architecture_overview(&self, repository_id: &str) -> Result<String, DomainError> {
         let (cg, graph) = self.create_clusters_with_graph(repository_id).await?;
 
         if cg.clusters.is_empty() {
@@ -932,8 +1107,87 @@ mod tests {
     }
 
     #[test]
+    fn test_enforce_connectivity_splits_disconnected_community() {
+        // Two disjoint edges forced into a single community must be split into
+        // two internally-connected communities.
+        let mut g = Graph::new(4);
+        g.add_edge(0, 1, 1.0);
+        g.add_edge(2, 3, 1.0);
+        let mut partition = vec![0, 0, 0, 0];
+        enforce_connectivity(&g, &mut partition);
+        assert_eq!(partition[0], partition[1]);
+        assert_eq!(partition[2], partition[3]);
+        assert_ne!(partition[0], partition[2]);
+    }
+
+    #[test]
+    fn test_enforce_connectivity_keeps_connected_intact() {
+        // A genuinely connected community is left untouched (one label).
+        let mut g = Graph::new(3);
+        g.add_edge(0, 1, 1.0);
+        g.add_edge(1, 2, 1.0);
+        let mut partition = vec![7, 7, 7];
+        enforce_connectivity(&g, &mut partition);
+        assert_eq!(partition[0], partition[1]);
+        assert_eq!(partition[1], partition[2]);
+    }
+
+    #[test]
+    fn test_split_oversized_subdivides_dominant_community() {
+        // Two 5-cliques joined by one weak bridge, forced into a single
+        // community (size 10 = 100% of the graph). split_oversized must break it
+        // back into the two cliques.
+        let mut g = Graph::new(10);
+        for i in 0..5 {
+            for j in (i + 1)..5 {
+                g.add_edge(i, j, 1.0);
+            }
+        }
+        for i in 5..10 {
+            for j in (i + 1)..10 {
+                g.add_edge(i, j, 1.0);
+            }
+        }
+        g.add_edge(0, 5, 0.1); // weak bridge
+
+        let mut partition = vec![0; 10];
+        split_oversized(&g, &mut partition);
+
+        assert!(
+            partition[0..5].iter().all(|&l| l == partition[0]),
+            "first clique should share one label: {:?}",
+            partition
+        );
+        assert!(
+            partition[5..10].iter().all(|&l| l == partition[5]),
+            "second clique should share one label: {:?}",
+            partition
+        );
+        assert_ne!(
+            partition[0], partition[5],
+            "the two cliques should land in different communities: {:?}",
+            partition
+        );
+    }
+
+    #[test]
+    fn test_split_oversized_leaves_small_communities() {
+        // Below MIN_SPLIT_SIZE nothing is touched even if one label dominates.
+        let mut g = Graph::new(4);
+        g.add_edge(0, 1, 1.0);
+        g.add_edge(1, 2, 1.0);
+        g.add_edge(2, 3, 1.0);
+        let mut partition = vec![0, 0, 0, 0];
+        split_oversized(&g, &mut partition);
+        assert!(partition.iter().all(|&l| l == 0));
+    }
+
+    #[test]
     fn test_name_cluster_uses_dir() {
-        let members = vec!["src/auth/login.rs".to_string(), "src/auth/logout.rs".to_string()];
+        let members = vec![
+            "src/auth/login.rs".to_string(),
+            "src/auth/logout.rs".to_string(),
+        ];
         let name = name_cluster(&members, &HashMap::new());
         assert!(name.contains("auth"), "expected 'auth' in '{}'", name);
     }

--- a/src/application/use_cases/cluster_detection.rs
+++ b/src/application/use_cases/cluster_detection.rs
@@ -3,27 +3,35 @@
 //! The algorithm follows Traag et al. (2019):
 //!   1. **Local moving** — each node greedily moves to the neighbour partition
 //!      that maximises modularity gain.
-//!   2. **Refinement** — a second greedy pass that lets nodes escape the local
-//!      optimum the moving phase settled into.
-//!   3. **Aggregation** — each partition is collapsed into a super-node and
-//!      the procedure repeats until the modularity gain is below `1e-6` or
-//!      50 iterations have elapsed.
+//!   2. **Refinement** — each community is rebuilt from singletons and its nodes
+//!      re-merged into well-connected sub-communities by a randomized,
+//!      gain-weighted pass (the step that makes this Leiden, not Louvain).
+//!   3. **Aggregation** — the *refined* partition is collapsed into super-nodes,
+//!      each seeded with its pre-refinement community, and the procedure repeats
+//!      until the modularity gain is below `1e-6` or 50 iterations have elapsed.
 //!
-//! The moving/refinement passes are modularity-greedy (Louvain-style) and do
-//! **not** by themselves guarantee that a community is internally connected —
-//! the defect Leiden was designed to fix. That guarantee is enforced explicitly
-//! as a post-pass ([`enforce_connectivity`]): any community that is not a single
-//! connected component in the induced subgraph is split into its components.
-//! A second post-pass ([`split_oversized`]) subdivides any community that grows
-//! to dominate the graph, so one mega-cluster cannot swallow the codebase.
+//! The refinement step ([`refine_partition`]) is the real thing: it rebuilds
+//! each community from singletons, re-merging nodes into well-connected
+//! sub-communities via a randomized, gain-weighted choice. This is what gives
+//! Leiden its two guarantees over Louvain — every community is internally
+//! connected, and the stochastic merges escape the local optima plain
+//! local-moving freezes into. Two post-passes then run for robustness:
+//! [`split_oversized`] subdivides any community that grows to dominate the graph
+//! (so one mega-cluster cannot swallow the codebase), and
+//! [`enforce_connectivity`] re-asserts the connectivity guarantee as a final
+//! safety net.
 //!
-//! All phases are deterministic: candidate clusters are visited in a stable
-//! order and graphs are built from sorted edge lists, so the same input always
-//! yields the same partition (cluster *membership*; the opaque UUIDs assigned to
-//! each cluster are not stable and carry no ordering meaning).
+//! The result is deterministic despite the randomness: the refinement RNG is
+//! seeded with a fixed constant ([`LEIDEN_SEED`]), candidate communities are
+//! visited in a stable order, and graphs are built from sorted edge lists, so
+//! the same input always yields the same partition (cluster *membership*; the
+//! opaque UUIDs assigned to each cluster are not stable and carry no ordering
+//! meaning).
 //!
-//! Edge weights are differentiated by reference kind (see `kind_weight`) so
-//! the algorithm clusters files that share strong semantic bonds.
+//! Edge weights are differentiated by reference kind (see [`kind_weight`]) so
+//! the algorithm clusters nodes that share strong semantic bonds. The graph
+//! primitives ([`Graph`], [`leiden`]) are `pub(crate)` so symbol-level community
+//! detection can reuse the exact same algorithm.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
@@ -52,7 +60,7 @@ const DEFAULT_KIND_WEIGHT: f64 = 0.3;
 /// Maximum character length for a generated cluster-name slug.
 const SLUG_MAX_LENGTH: usize = 30;
 
-fn kind_weight(kind: &str) -> f64 {
+pub(crate) fn kind_weight(kind: &str) -> f64 {
     match kind.to_lowercase().as_str() {
         "call" | "methodcall" => CALL_WEIGHT,
         "inheritance" => INHERITANCE_WEIGHT,
@@ -83,40 +91,112 @@ fn composite_weight(edge: &FileEdge) -> f64 {
 // ── Graph representation ──────────────────────────────────────────────────
 
 /// A compact undirected weighted graph stored as adjacency lists.
+///
+/// Exposed at `pub(crate)` so other use cases (e.g. symbol-level community
+/// detection) can build a graph and run [`leiden`] on it without duplicating the
+/// algorithm.
 #[derive(Clone)]
-struct Graph {
+pub(crate) struct Graph {
     /// Number of nodes.
     n: usize,
     /// `adj[u]` = list of (neighbour, weight) pairs (undirected: stored in both directions).
     adj: Vec<Vec<(usize, f64)>>,
     /// Total weight of all edges (each undirected edge counted once), including self-loops.
     total_weight: f64,
-    /// Weighted degree of each node: sum of incident edge weights.
+    /// Weighted degree of each node: sum of incident edge weights (a self-loop
+    /// contributes twice, as it touches the node at both ends).
     degree: Vec<f64>,
-    /// Sum of self-loop weights accumulated during graph aggregation.
+    /// Per-node self-loop weight, accumulated during graph aggregation.
     ///
-    /// Self-loops are not stored in `adj` (they would create spurious neighbours),
-    /// but their mass must be included in the internal-edge term of [`modularity`].
-    self_loop_weight: f64,
+    /// Self-loops are not stored in `adj` (they would create spurious
+    /// neighbours), but their mass is internal to whichever community the node
+    /// belongs to and must be included in the internal-edge term of
+    /// [`modularity`]. Tracking it per node (rather than as one scalar) lets the
+    /// multi-level Leiden recursion carry intra-community mass forward correctly
+    /// across successive aggregations.
+    self_loops: Vec<f64>,
 }
 
 impl Graph {
-    fn new(n: usize) -> Self {
+    pub(crate) fn new(n: usize) -> Self {
         Self {
             n,
             adj: vec![Vec::new(); n],
             total_weight: 0.0,
             degree: vec![0.0; n],
-            self_loop_weight: 0.0,
+            self_loops: vec![0.0; n],
         }
     }
 
-    fn add_edge(&mut self, u: usize, v: usize, w: f64) {
+    pub(crate) fn add_edge(&mut self, u: usize, v: usize, w: f64) {
         self.adj[u].push((v, w));
         self.adj[v].push((u, w));
         self.degree[u] += w;
         self.degree[v] += w;
         self.total_weight += w;
+    }
+
+    /// Add `w` of self-loop mass to `node`. A self-loop touches the node twice,
+    /// so it adds `2w` to the weighted degree but `w` to the total edge weight.
+    fn add_self_loop(&mut self, node: usize, w: f64) {
+        if w == 0.0 {
+            return;
+        }
+        self.self_loops[node] += w;
+        self.degree[node] += 2.0 * w;
+        self.total_weight += w;
+    }
+
+    /// Total self-loop (intra-community) mass across all nodes.
+    fn self_loop_total(&self) -> f64 {
+        self.self_loops.iter().sum()
+    }
+}
+
+// ── Deterministic PRNG ────────────────────────────────────────────────────
+
+/// Fixed seed for the refinement RNG. Leiden's refinement is stochastic by
+/// design (that randomness is what lets it escape the local optima Louvain gets
+/// stuck in); seeding it with a constant keeps the result reproducible across
+/// runs and processes while preserving the exploration.
+const LEIDEN_SEED: u64 = 0x5EED_1DEA_C0DE_F00D;
+
+/// Theta controls how sharply refinement prefers higher-gain merges: smaller →
+/// greedier, larger → more uniform exploration. Mid-range keeps some stochastic
+/// exploration without diluting clearly-better merges.
+const REFINE_THETA: f64 = 0.05;
+
+/// Minimal self-contained SplitMix64 PRNG — avoids pulling in the `rand` crate
+/// for the handful of values the refinement needs.
+struct SplitMix64 {
+    state: u64,
+}
+
+impl SplitMix64 {
+    fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// Uniform f64 in `[0, 1)`.
+    fn next_f64(&mut self) -> f64 {
+        // 53-bit mantissa for a uniform double.
+        (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64
+    }
+}
+
+/// In-place Fisher–Yates shuffle using `rng`.
+fn shuffle<T>(items: &mut [T], rng: &mut SplitMix64) {
+    for i in (1..items.len()).rev() {
+        let j = (rng.next_u64() % (i as u64 + 1)) as usize;
+        items.swap(i, j);
     }
 }
 
@@ -135,10 +215,10 @@ const MIN_SPLIT_SIZE: usize = 10;
 /// Run Leiden cluster detection on `graph` and return a partition: a
 /// `Vec<usize>` where `partition[node_index]` is the cluster id.
 ///
-/// This is the modularity-greedy core ([`leiden_core`]) followed by the two
-/// guarantee-enforcing post-passes ([`enforce_connectivity`] then
-/// [`split_oversized`]); labels are renumbered contiguously at the end.
-fn leiden(graph: &Graph) -> Vec<usize> {
+/// This is the Leiden core ([`leiden_core`]) followed by the two
+/// guarantee-enforcing post-passes ([`split_oversized`] then
+/// [`enforce_connectivity`]); labels are renumbered contiguously at the end.
+pub(crate) fn leiden(graph: &Graph) -> Vec<usize> {
     if graph.n == 0 {
         return Vec::new();
     }
@@ -147,59 +227,80 @@ fn leiden(graph: &Graph) -> Vec<usize> {
     // Split any community that dominates the graph (uses the bare core on the
     // induced subgraph, so this does not recurse through the post-passes).
     split_oversized(graph, &mut result);
-    // Guarantee every final community is internally connected. Run last so that
-    // pieces produced by the oversized split are also connectivity-checked.
+    // Belt-and-braces: true Leiden refinement already yields connected
+    // communities, but the oversized split and any future change could not, so
+    // re-assert the guarantee as the final step.
     enforce_connectivity(graph, &mut result);
     renumber(&mut result);
     result
 }
 
-/// The bare modularity-greedy algorithm (local moving + refinement +
-/// aggregation), returning a partition mapped back to the original nodes. The
-/// labels are **not** renumbered and the connectivity / oversized guarantees are
-/// **not** enforced here — that is [`leiden`]'s job. Kept separate so the
-/// oversized-split post-pass can re-cluster a subgraph without re-triggering the
-/// post-passes (which would recurse indefinitely on an indivisible blob).
+/// The Leiden core (Traag et al. 2019): repeatedly (1) move nodes to the
+/// best neighbouring community, (2) **refine** each community into
+/// well-connected sub-communities via a randomized, gain-weighted pass, then
+/// (3) aggregate the graph using the *refined* partition while seeding the next
+/// level from the *unrefined* community of each node. The refinement is what
+/// separates Leiden from Louvain: it guarantees every community is internally
+/// connected and lets the search escape the local optima plain local-moving
+/// settles into.
+///
+/// Returns a partition mapped back to the original nodes (not renumbered, no
+/// post-passes — that is [`leiden`]'s job, kept separate so [`split_oversized`]
+/// can re-cluster a subgraph without recursing through the post-passes).
 fn leiden_core(graph: &Graph) -> Vec<usize> {
     if graph.n == 0 {
         return Vec::new();
     }
 
-    // Start: every node in its own cluster.
-    let mut partition: Vec<usize> = (0..graph.n).collect();
-    let mut prev_modularity = modularity(graph, &partition);
-    let mut current_graph = graph.clone();
-    let mut node_to_supernode: Vec<usize> = (0..graph.n).collect();
+    let mut rng = SplitMix64::new(LEIDEN_SEED);
+    let mut current = graph.clone();
+    // Partition `p` over the current (aggregated) graph's nodes.
+    let mut partition: Vec<usize> = (0..current.n).collect();
+    // Map every original node to its node index in `current`.
+    let mut node_to_super: Vec<usize> = (0..graph.n).collect();
+    let mut prev_modularity = f64::NEG_INFINITY;
 
     for _ in 0..MAX_ITERATIONS {
-        local_moving_phase(&current_graph, &mut partition);
-        refine_phase(&current_graph, &mut partition);
+        local_moving_phase(&current, &mut partition);
+        renumber(&mut partition);
 
-        // Aggregation step: collapse each partition into a super-node.
-        let (new_graph, new_partition) = aggregate_partition(&current_graph, &partition);
+        let num_communities = partition.iter().copied().max().map(|m| m + 1).unwrap_or(0);
+        let q = modularity(&current, &partition);
 
-        // Update the mapping from original nodes to supernodes.
-        for node in 0..node_to_supernode.len() {
-            let supernode = node_to_supernode[node];
-            node_to_supernode[node] = partition[supernode];
-        }
-
-        current_graph = new_graph;
-        partition = new_partition;
-
-        let new_modularity = modularity(&current_graph, &partition);
-        if new_modularity - prev_modularity < MIN_MODULARITY_GAIN {
+        // Nothing left to aggregate (every node already its own community) or no
+        // meaningful modularity improvement: stop with the current partition.
+        if num_communities >= current.n || q - prev_modularity < MIN_MODULARITY_GAIN {
             break;
         }
-        prev_modularity = new_modularity;
+        prev_modularity = q;
+
+        // Refine each community into well-connected sub-communities.
+        let mut refined = refine_partition(&current, &partition, &mut rng);
+        renumber(&mut refined);
+
+        // Aggregate by the refined partition; `super_of[node]` is the new
+        // super-node index for each current node.
+        let (aggregated, super_of) = aggregate_by(&current, &refined);
+
+        // Seed the next level's partition from the *unrefined* community: every
+        // refined sub-community (now a super-node) inherits the community it was
+        // refined out of, so local moving resumes from the coarse structure.
+        let mut next_partition = vec![0usize; aggregated.n];
+        for node in 0..current.n {
+            next_partition[super_of[node]] = partition[node];
+        }
+
+        // Compose the original→super mapping through this aggregation.
+        for slot in node_to_super.iter_mut() {
+            *slot = super_of[*slot];
+        }
+
+        current = aggregated;
+        partition = next_partition;
     }
 
-    // Map back to original nodes.
     (0..graph.n)
-        .map(|node| {
-            let supernode = node_to_supernode[node];
-            partition[supernode]
-        })
+        .map(|node| partition[node_to_super[node]])
         .collect()
 }
 
@@ -336,8 +437,9 @@ fn modularity(graph: &Graph, partition: &[usize]) -> f64 {
         }
     }
     // Self-loop mass was collapsed from intra-cluster edges during aggregation;
-    // it represents internal weight that must be counted alongside adj edges.
-    q += graph.self_loop_weight;
+    // it is always internal to a node's own community, so it is counted
+    // unconditionally alongside the intra-community adj edges.
+    q += graph.self_loop_total();
     q /= graph.total_weight;
 
     // Subtract expected: Σ_c (Σ_i∈c k_i)^2 / (2m)^2
@@ -420,70 +522,102 @@ fn local_moving_phase(graph: &Graph, partition: &mut Vec<usize>) {
     }
 }
 
-/// Refinement phase: a second greedy pass that lets nodes escape the local
-/// optimum the moving phase settled into. For each node we take the first
-/// neighbouring cluster (in ascending id order) that yields a positive
-/// modularity gain. We iterate once over all nodes to keep runtime bounded.
+/// Leiden refinement: within each community of `community` (the partition
+/// produced by local moving), break the community back into singletons and
+/// re-merge nodes into well-connected sub-communities.
 ///
-/// Note: this pass does **not** guarantee internally-connected communities —
-/// that is enforced separately by [`enforce_connectivity`] after the algorithm
-/// converges. The candidate order is deterministic so the partition is stable
-/// across runs.
-fn refine_phase(graph: &Graph, partition: &mut Vec<usize>) {
+/// Each still-isolated node is offered the neighbouring sub-communities **inside
+/// its own community** whose modularity gain is non-negative, and is merged into
+/// one chosen stochastically with probability proportional to `exp(gain / θ)`.
+/// Two properties fall out of this:
+/// * **Connectivity** — a sub-community only ever grows by absorbing a node that
+///   has an edge into it, so every resulting sub-community is connected.
+/// * **Escape from local optima** — the randomized, gain-weighted choice lets
+///   Leiden split communities Louvain would have frozen, the defect this whole
+///   change is about.
+///
+/// Returns the refined sub-community label per node (not yet renumbered).
+fn refine_partition(graph: &Graph, community: &[usize], rng: &mut SplitMix64) -> Vec<usize> {
+    let n = graph.n;
+    // Every node starts in its own singleton sub-community (id == node index).
+    let mut refined: Vec<usize> = (0..n).collect();
     let m2 = 2.0 * graph.total_weight;
     if m2 == 0.0 {
-        return;
+        return refined;
     }
+    // Weighted-degree sum and node count of each refined sub-community.
+    let mut sub_degree: Vec<f64> = graph.degree.clone();
+    let mut sub_size: Vec<usize> = vec![1; n];
 
-    let mut cluster_total: HashMap<usize, f64> = HashMap::new();
-    for u in 0..graph.n {
-        *cluster_total.entry(partition[u]).or_insert(0.0) += graph.degree[u];
-    }
+    let mut order: Vec<usize> = (0..n).collect();
+    shuffle(&mut order, rng);
 
-    for u in 0..graph.n {
-        let cu = partition[u];
-        let ku = graph.degree[u];
+    for &v in &order {
+        // Only nodes still alone in their sub-community may be merged — this is
+        // what keeps refined sub-communities well-connected.
+        if sub_size[refined[v]] != 1 {
+            continue;
+        }
+        let cv = community[v];
+        let kv = graph.degree[v];
 
-        // Collect distinct neighbouring clusters.
-        let mut neighbours: Vec<usize> = graph.adj[u]
-            .iter()
-            .map(|&(v, _)| partition[v])
-            .filter(|&c| c != cu)
-            .collect();
-        neighbours.sort_unstable();
-        neighbours.dedup();
-
-        if neighbours.is_empty() {
+        // Edge weight from v to each candidate sub-community within v's community.
+        let mut weight_to: HashMap<usize, f64> = HashMap::new();
+        for &(u, w) in &graph.adj[v] {
+            if community[u] == cv && refined[u] != refined[v] {
+                *weight_to.entry(refined[u]).or_insert(0.0) += w;
+            }
+        }
+        if weight_to.is_empty() {
             continue;
         }
 
-        // Weight from u to each candidate cluster.
-        let sigma_cu = *cluster_total.get(&cu).unwrap_or(&0.0);
-        let ku_in: f64 = graph.adj[u]
-            .iter()
-            .filter(|&&(v, _)| partition[v] == cu)
-            .map(|&(_, w)| w)
-            .sum();
-        let remove_gain = ku_in - ku * (sigma_cu - ku) / m2;
-
-        // Try each neighbouring cluster (deterministic — no actual randomness
-        // needed for the correctness guarantee; we just visit all candidates).
-        for ct in neighbours {
-            let w_to_ct: f64 = graph.adj[u]
-                .iter()
-                .filter(|&&(v, _)| partition[v] == ct)
-                .map(|&(_, w)| w)
-                .sum();
-            let sigma_ct = *cluster_total.get(&ct).unwrap_or(&0.0);
-            let gain = w_to_ct - ku * sigma_ct / m2 + remove_gain;
-            if gain > 0.0 {
-                *cluster_total.entry(cu).or_insert(0.0) -= ku;
-                *cluster_total.entry(ct).or_insert(0.0) += ku;
-                partition[u] = ct;
-                break; // take first improving move
+        // Candidate sub-communities with non-negative modularity gain, visited in
+        // ascending id so the (seeded) sampling below is reproducible.
+        let mut candidates: Vec<(usize, f64)> = weight_to.into_iter().collect();
+        candidates.sort_unstable_by_key(|&(c, _)| c);
+        let mut gains: Vec<(usize, f64)> = Vec::new();
+        for (c, w_to_c) in candidates {
+            // Merging a singleton into c: gain = w_to_c - k_v * Σ_c / 2m
+            // (the singleton has no internal mass, so its removal cost is 0).
+            let gain = w_to_c - kv * sub_degree[c] / m2;
+            if gain >= 0.0 {
+                gains.push((c, gain));
             }
         }
+        if gains.is_empty() {
+            continue;
+        }
+
+        // Sample a target ~ exp(gain / θ), shifted by the max gain for numerical
+        // stability.
+        let max_gain = gains.iter().map(|&(_, g)| g).fold(f64::MIN, f64::max);
+        let weights: Vec<f64> = gains
+            .iter()
+            .map(|&(_, g)| ((g - max_gain) / REFINE_THETA).exp())
+            .collect();
+        let total: f64 = weights.iter().sum();
+        let threshold = rng.next_f64() * total;
+        let mut acc = 0.0;
+        let mut chosen = gains[0].0;
+        for (idx, &w) in weights.iter().enumerate() {
+            acc += w;
+            if threshold <= acc {
+                chosen = gains[idx].0;
+                break;
+            }
+        }
+
+        // Merge v into the chosen sub-community.
+        let old = refined[v];
+        refined[v] = chosen;
+        sub_degree[chosen] += kv;
+        sub_degree[old] -= kv;
+        sub_size[chosen] += 1;
+        sub_size[old] -= 1;
     }
+
+    refined
 }
 
 /// Renumber partition labels to be contiguous starting from 0.
@@ -496,68 +630,57 @@ fn renumber(partition: &mut Vec<usize>) {
     }
 }
 
-/// Aggregate a graph by collapsing each partition into a super-node.
+/// Aggregate `graph` by collapsing each group in `membership` (assumed
+/// contiguous `0..k`) into a single super-node.
 ///
-/// Returns a new graph where each node represents a cluster from the original
-/// partition, and a new partition mapping (where each super-node is in its own cluster).
-fn aggregate_partition(graph: &Graph, partition: &[usize]) -> (Graph, Vec<usize>) {
-    // Build mapping from old cluster ID to new node index.
-    let num_clusters = partition.iter().copied().max().map(|m| m + 1).unwrap_or(0);
+/// Returns the aggregated graph together with `super_of`, where
+/// `super_of[node]` is the super-node index of each original node (== its
+/// `membership`). Intra-group edges and each node's existing self-loop mass are
+/// carried forward as the super-node's self-loop, so total edge weight is
+/// conserved across aggregation levels.
+fn aggregate_by(graph: &Graph, membership: &[usize]) -> (Graph, Vec<usize>) {
+    let num = membership.iter().copied().max().map(|m| m + 1).unwrap_or(0);
+    let mut new_graph = Graph::new(num);
 
-    // Create new graph with one node per cluster.
-    let mut new_graph = Graph::new(num_clusters);
-
-    // Aggregate edge weights between clusters.
-    let mut edge_weights: HashMap<(usize, usize), f64> = HashMap::new();
+    let mut inter: HashMap<(usize, usize), f64> = HashMap::new();
+    let mut self_mass: Vec<f64> = vec![0.0; num];
 
     for u in 0..graph.n {
-        let cu = partition[u];
+        let cu = membership[u];
+        // Carry this node's own self-loop mass into its super-node.
+        self_mass[cu] += graph.self_loops[u];
         for &(v, w) in &graph.adj[u] {
             if v <= u {
-                continue; // Process each edge only once.
+                continue; // each undirected edge once
             }
-            let cv = partition[v];
+            let cv = membership[v];
             if cu == cv {
-                // Intra-cluster edge becomes a self-loop on the super-node.
-                // Accumulate its weight so that total_weight and degree remain
-                // consistent with the original graph, which is required for
-                // correct modularity and delta-gain computations on the coarse graph.
-                *edge_weights.entry((cu, cu)).or_insert(0.0) += w;
+                self_mass[cu] += w;
             } else {
                 let (lo, hi) = if cu < cv { (cu, cv) } else { (cv, cu) };
-                *edge_weights.entry((lo, hi)).or_insert(0.0) += w;
+                *inter.entry((lo, hi)).or_insert(0.0) += w;
             }
         }
     }
 
-    // Add aggregated edges to new graph in a deterministic order (HashMap
-    // iteration order is process-randomised, and adjacency-list ordering feeds
-    // back into later phases, so sort the collapsed edges before inserting).
-    // Self-loops (u == v) must contribute to total_weight and degree but must
-    // NOT appear in adj — movement decisions only involve distinct neighbours,
-    // and a self-loop would create a spurious neighbour entry for a node.
-    let mut aggregated: Vec<((usize, usize), f64)> = edge_weights.into_iter().collect();
-    aggregated.sort_unstable_by_key(|&((u, v), _)| (u, v));
-    for ((u, v), w) in aggregated {
-        if u == v {
-            new_graph.total_weight += w;
-            new_graph.degree[u] += 2.0 * w; // both endpoints collapse to the same super-node
-            new_graph.self_loop_weight += w;
-        } else {
-            new_graph.add_edge(u, v, w);
-        }
+    // Insert in deterministic order (HashMap iteration is process-randomised and
+    // adjacency ordering feeds back into later phases).
+    let mut inter_edges: Vec<((usize, usize), f64)> = inter.into_iter().collect();
+    inter_edges.sort_unstable_by_key(|&((u, v), _)| (u, v));
+    for ((u, v), w) in inter_edges {
+        new_graph.add_edge(u, v, w);
+    }
+    for (node, &w) in self_mass.iter().enumerate() {
+        new_graph.add_self_loop(node, w);
     }
 
-    // New partition: each super-node is initially in its own cluster.
-    let new_partition: Vec<usize> = (0..num_clusters).collect();
-
-    (new_graph, new_partition)
+    (new_graph, membership.to_vec())
 }
 
 // ── Cluster naming ────────────────────────────────────────────────────────
 
 /// Common words excluded when extracting meaningful keywords from symbol names.
-const STOP_WORDS: &[&str] = &[
+pub(crate) const STOP_WORDS: &[&str] = &[
     "get", "set", "test", "new", "is", "has", "to", "from", "with", "the", "and", "or", "of", "in",
     "at", "by", "for",
 ];
@@ -642,7 +765,7 @@ fn name_cluster(members: &[String], symbol_map: &HashMap<String, String>) -> Str
 }
 
 /// Split a camelCase or snake_case identifier into words.
-fn split_identifier(s: &str) -> Vec<&str> {
+pub(crate) fn split_identifier(s: &str) -> Vec<&str> {
     // Try snake_case first.
     if s.contains('_') {
         return s.split('_').filter(|w| !w.is_empty()).collect();
@@ -662,7 +785,7 @@ fn split_identifier(s: &str) -> Vec<&str> {
 }
 
 /// Convert a string to a lowercase slug, truncated to `max_len` characters.
-fn slugify(s: &str, max_len: usize) -> String {
+pub(crate) fn slugify(s: &str, max_len: usize) -> String {
     let slug: String = s
         .chars()
         .map(|c| {
@@ -1180,6 +1303,85 @@ mod tests {
         let mut partition = vec![0, 0, 0, 0];
         split_oversized(&g, &mut partition);
         assert!(partition.iter().all(|&l| l == 0));
+    }
+
+    /// Build two `size`-cliques joined by a single weak bridge edge.
+    fn two_cliques(size: usize, bridge_weight: f64) -> Graph {
+        let mut g = Graph::new(size * 2);
+        for (base, _) in [(0usize, ()), (size, ())] {
+            for i in base..base + size {
+                for j in (i + 1)..base + size {
+                    g.add_edge(i, j, 1.0);
+                }
+            }
+        }
+        g.add_edge(0, size, bridge_weight);
+        g
+    }
+
+    #[test]
+    fn test_leiden_separates_two_cliques() {
+        // The real refinement must recover the two cliques as separate,
+        // internally-connected communities.
+        let g = two_cliques(6, 0.05);
+        let partition = leiden(&g);
+        assert!(
+            partition[0..6].iter().all(|&l| l == partition[0]),
+            "first clique split: {:?}",
+            partition
+        );
+        assert!(
+            partition[6..12].iter().all(|&l| l == partition[6]),
+            "second clique split: {:?}",
+            partition
+        );
+        assert_ne!(
+            partition[0], partition[6],
+            "cliques merged: {:?}",
+            partition
+        );
+    }
+
+    #[test]
+    fn test_leiden_is_deterministic() {
+        // Seeded refinement ⇒ identical partitions across repeated runs.
+        let g = two_cliques(8, 0.1);
+        assert_eq!(leiden(&g), leiden(&g));
+    }
+
+    #[test]
+    fn test_leiden_communities_are_connected() {
+        // Every community Leiden returns must be a single connected component of
+        // the induced subgraph (the guarantee that distinguishes it from Louvain).
+        let g = two_cliques(7, 0.05);
+        let partition = leiden(&g);
+
+        let num = partition.iter().copied().max().unwrap() + 1;
+        for community in 0..num {
+            let members: Vec<usize> = (0..g.n).filter(|&i| partition[i] == community).collect();
+            if members.len() < 2 {
+                continue;
+            }
+            // BFS within the community from the first member.
+            let set: std::collections::HashSet<usize> = members.iter().copied().collect();
+            let mut seen = std::collections::HashSet::new();
+            let mut stack = vec![members[0]];
+            seen.insert(members[0]);
+            while let Some(u) = stack.pop() {
+                for &(v, _) in &g.adj[u] {
+                    if set.contains(&v) && seen.insert(v) {
+                        stack.push(v);
+                    }
+                }
+            }
+            assert_eq!(
+                seen.len(),
+                members.len(),
+                "community {} is not internally connected: {:?}",
+                community,
+                members
+            );
+        }
     }
 
     #[test]

--- a/src/application/use_cases/impact_analysis.rs
+++ b/src/application/use_cases/impact_analysis.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::application::use_cases::pattern_utils::build_fuzzy_pattern;
 use crate::application::{CallGraphQuery, CallGraphUseCase};
@@ -11,9 +11,29 @@ use crate::domain::DomainError;
 
 pub const ANONYMOUS_SYMBOL: &str = "<anonymous>";
 
-/// Maximum number of fully-qualified symbols to resolve from a short name during
-/// fallback resolution. Caps the ambiguity fan-out without blocking common cases.
-const RESOLVE_SYMBOLS_LIMIT: u32 = 10;
+/// Maximum number of fully-qualified symbols to resolve from a short name before
+/// seeding the blast-radius BFS. Caps the ambiguity fan-out; when a name resolves
+/// to more than this many FQNs the extras are dropped and the result is flagged
+/// as truncated (see [`ImpactAnalysisUseCase::resolve_capped`]) rather than
+/// silently analysing an arbitrary alphabetical slice.
+const RESOLVE_SYMBOLS_LIMIT: u32 = 100;
+
+/// Build the human-readable label for the analysed symbol from its resolved
+/// roots. A single root is shown verbatim; multiple roots show the count, with a
+/// `+ … capped` note when resolution hit [`RESOLVE_SYMBOLS_LIMIT`] so the user
+/// knows the blast radius is partial.
+fn display_label(symbol: &str, resolved: &[String], truncated: bool) -> String {
+    match resolved.len() {
+        1 => resolved[0].clone(),
+        n if truncated => {
+            format!(
+                "{} ({}+ symbols, capped at {})",
+                symbol, n, RESOLVE_SYMBOLS_LIMIT
+            )
+        }
+        n => format!("{} ({} symbols)", symbol, n),
+    }
+}
 
 /// A single node in the impact (blast-radius) graph.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -118,6 +138,37 @@ impl ImpactAnalysisUseCase {
         Self { call_graph }
     }
 
+    /// Resolve `pattern` to root symbols, capped at [`RESOLVE_SYMBOLS_LIMIT`].
+    ///
+    /// Asks the repository for one row beyond the cap so that hitting the cap can
+    /// be detected: when more matches exist than the cap, the extras are dropped
+    /// and `true` is returned for the truncation flag (and a warning is logged),
+    /// so the blast radius is never silently computed over an arbitrary
+    /// alphabetical slice of a larger match set.
+    async fn resolve_capped(
+        &self,
+        pattern: &str,
+        query: &CallGraphQuery,
+    ) -> Result<(Vec<String>, bool), DomainError> {
+        let mut resolved = self
+            .call_graph
+            .resolve_symbols(pattern, query, RESOLVE_SYMBOLS_LIMIT + 1)
+            .await?;
+        let truncated = resolved.len() as u32 > RESOLVE_SYMBOLS_LIMIT;
+        if truncated {
+            resolved.truncate(RESOLVE_SYMBOLS_LIMIT as usize);
+            warn!(
+                pattern,
+                cap = RESOLVE_SYMBOLS_LIMIT,
+                "impact: symbol resolved to more than {} FQNs; blast radius covers \
+                 only the first {} — narrow the symbol for a complete result",
+                RESOLVE_SYMBOLS_LIMIT,
+                RESOLVE_SYMBOLS_LIMIT
+            );
+        }
+        Ok((resolved, truncated))
+    }
+
     /// Compute blast radius.
     ///
     /// `symbol`        – symbol name or substring to analyse (e.g. `"authenticate"`),
@@ -149,17 +200,11 @@ impl ImpactAnalysisUseCase {
         // Determine the set of root symbols to BFS from and a display label.
         let (root_symbols, display_symbol): (Vec<String>, String) = if is_regex {
             // Regex mode: always resolve via pattern matching; never try an exact hit.
-            let resolved = self
-                .call_graph
-                .resolve_symbols(symbol, &query, RESOLVE_SYMBOLS_LIMIT)
-                .await?;
+            let (resolved, truncated) = self.resolve_capped(symbol, &query).await?;
             if resolved.is_empty() {
                 (vec![symbol.to_string()], symbol.to_string())
-            } else if resolved.len() == 1 {
-                let s = resolved[0].clone();
-                (resolved, s)
             } else {
-                let display = format!("{} ({} symbols)", symbol, resolved.len());
+                let display = display_label(symbol, &resolved, truncated);
                 (resolved, display)
             }
         } else {
@@ -168,10 +213,7 @@ impl ImpactAnalysisUseCase {
             // caller_symbol).  This correctly handles root entry-point symbols
             // that have zero callers but appear as caller_symbol — find_callers
             // would return empty for them, incorrectly triggering fuzzy expansion.
-            let exact_resolved = self
-                .call_graph
-                .resolve_symbols(symbol, &query, RESOLVE_SYMBOLS_LIMIT)
-                .await?;
+            let (exact_resolved, exact_truncated) = self.resolve_capped(symbol, &query).await?;
             if !exact_resolved.is_empty() {
                 debug!(
                     symbol,
@@ -179,11 +221,7 @@ impl ImpactAnalysisUseCase {
                     "impact: exact-match found {} symbols",
                     exact_resolved.len()
                 );
-                let display = if exact_resolved.len() == 1 {
-                    exact_resolved[0].clone()
-                } else {
-                    format!("{} ({} symbols)", symbol, exact_resolved.len())
-                };
+                let display = display_label(symbol, &exact_resolved, exact_truncated);
                 (exact_resolved, display)
             } else {
                 let auto_pattern = format!(".*{}.*", build_fuzzy_pattern(symbol));
@@ -192,10 +230,7 @@ impl ImpactAnalysisUseCase {
                     symbol,
                     auto_pattern, "impact: exact-match empty, trying auto-wrap regex"
                 );
-                let resolved = self
-                    .call_graph
-                    .resolve_symbols(&auto_pattern, &auto_query, RESOLVE_SYMBOLS_LIMIT)
-                    .await?;
+                let (resolved, truncated) = self.resolve_capped(&auto_pattern, &auto_query).await?;
                 debug!(
                     symbol,
                     resolved_count = resolved.len(),
@@ -208,11 +243,8 @@ impl ImpactAnalysisUseCase {
                         "impact: no rows match pattern — symbol may not be indexed"
                     );
                     (vec![symbol.to_string()], symbol.to_string())
-                } else if resolved.len() == 1 {
-                    let s = resolved[0].clone();
-                    (resolved, s)
                 } else {
-                    let display = format!("{} ({} symbols)", symbol, resolved.len());
+                    let display = display_label(symbol, &resolved, truncated);
                     (resolved, display)
                 }
             }

--- a/src/application/use_cases/mod.rs
+++ b/src/application/use_cases/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod pattern_utils;
 mod rrf_fuse;
 mod search_code;
 mod snippet_lookup;
+mod symbol_cluster_detection;
 mod symbol_context;
 
 pub use call_graph::*;
@@ -25,4 +26,5 @@ pub use list_repositories::*;
 pub use rrf_fuse::*;
 pub use search_code::*;
 pub use snippet_lookup::*;
+pub use symbol_cluster_detection::*;
 pub use symbol_context::*;

--- a/src/application/use_cases/symbol_cluster_detection.rs
+++ b/src/application/use_cases/symbol_cluster_detection.rs
@@ -1,0 +1,395 @@
+//! Symbol-level community detection over the call graph.
+//!
+//! Where [`super::cluster_detection`] clusters *files* into architectural
+//! modules, this use case runs the very same Leiden algorithm one level down —
+//! over the **symbol** call graph (`symbol_references`). Nodes are individual
+//! symbols (functions, methods, types) and edges are caller→callee references
+//! weighted by reference kind. The resulting communities are behavioural units
+//! (a feature, a collaborating set of functions) that frequently cut across file
+//! and even directory boundaries, which the file-level view cannot show.
+//!
+//! The graph primitives and the algorithm are reused verbatim from
+//! `cluster_detection` (`Graph`, `leiden`, `kind_weight`, naming helpers) so the
+//! two levels stay behaviourally identical and benefit from the same fixes.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use super::cluster_detection::{kind_weight, leiden, slugify, split_identifier, Graph, STOP_WORDS};
+use crate::application::CallGraphUseCase;
+use crate::domain::{DomainError, SymbolCommunity, SymbolCommunityGraph};
+
+/// Maximum length of a generated community-name slug.
+const NAME_MAX_LENGTH: usize = 30;
+/// Minimum keyword length considered meaningful for naming.
+const MIN_KEYWORD_LEN: usize = 3;
+
+/// Use case: detect communities of tightly-coupled symbols in a repository's
+/// call graph and answer membership queries against them.
+pub struct SymbolClusterDetectionUseCase {
+    call_graph: Arc<CallGraphUseCase>,
+}
+
+/// The intermediate symbol graph plus the bookkeeping needed to turn a Leiden
+/// partition into named, scored communities.
+struct SymbolGraph {
+    /// Symbol FQN per node index (ascending, deduplicated).
+    symbols: Vec<String>,
+    /// The weighted undirected graph handed to Leiden.
+    graph: Graph,
+    /// Dominant language per symbol (first seen wins).
+    language_of: HashMap<String, String>,
+    /// Distinct undirected (lo, hi) node pairs that carry an edge — used both as
+    /// the edge count and to compute per-community cohesion.
+    edges: Vec<(usize, usize)>,
+}
+
+impl SymbolClusterDetectionUseCase {
+    pub fn new(call_graph: Arc<CallGraphUseCase>) -> Self {
+        Self { call_graph }
+    }
+
+    /// Detect all symbol communities in `repository_id`.
+    pub async fn detect_communities(
+        &self,
+        repository_id: &str,
+    ) -> Result<SymbolCommunityGraph, DomainError> {
+        let sg = self.build_symbol_graph(repository_id).await?;
+        let total_symbols = sg.symbols.len();
+        let total_edges = sg.edges.len();
+
+        if total_symbols == 0 || total_edges == 0 {
+            return Ok(SymbolCommunityGraph {
+                communities: Vec::new(),
+                repository_id: repository_id.to_string(),
+                total_symbols,
+                total_edges,
+            });
+        }
+
+        let partition = leiden(&sg.graph);
+        let num_communities = partition.iter().copied().max().map(|m| m + 1).unwrap_or(0);
+
+        // Group member symbols by community label.
+        let mut members_by_community: Vec<Vec<String>> = vec![Vec::new(); num_communities];
+        for (idx, &label) in partition.iter().enumerate() {
+            members_by_community[label].push(sg.symbols[idx].clone());
+        }
+        for members in &mut members_by_community {
+            members.sort();
+        }
+
+        // Internal / external edge counts per community for cohesion.
+        let mut internal: Vec<usize> = vec![0; num_communities];
+        let mut external: Vec<usize> = vec![0; num_communities];
+        for &(a, b) in &sg.edges {
+            let (ca, cb) = (partition[a], partition[b]);
+            if ca == cb {
+                internal[ca] += 1;
+            } else {
+                external[ca] += 1;
+                external[cb] += 1;
+            }
+        }
+
+        let mut communities: Vec<SymbolCommunity> = members_by_community
+            .iter()
+            .enumerate()
+            .filter(|(_, m)| !m.is_empty())
+            .map(|(label, members)| {
+                let cohesion = {
+                    let (i, e) = (internal[label], external[label]);
+                    if i + e == 0 {
+                        0.0_f32
+                    } else {
+                        i as f32 / (i + e) as f32
+                    }
+                };
+                SymbolCommunity {
+                    id: Uuid::new_v4().to_string(),
+                    name: name_symbol_community(members),
+                    repository_id: repository_id.to_string(),
+                    dominant_language: dominant_language(members, &sg.language_of),
+                    size: members.len(),
+                    cohesion,
+                    members: members.clone(),
+                }
+            })
+            .collect();
+
+        // Largest first, then name for a stable order.
+        communities.sort_by(|a, b| b.size.cmp(&a.size).then(a.name.cmp(&b.name)));
+
+        Ok(SymbolCommunityGraph {
+            communities,
+            repository_id: repository_id.to_string(),
+            total_symbols,
+            total_edges,
+        })
+    }
+
+    /// Return the community that `symbol` belongs to, or `None` if the symbol is
+    /// not part of any community (unknown, or isolated in the call graph).
+    ///
+    /// Matching prefers an exact fully-qualified hit, then a boundary suffix
+    /// match (so a short `authenticate` finds `pkg/Auth#authenticate().`), then a
+    /// substring match — always case-sensitive, mirroring the call-graph queries.
+    pub async fn community_for_symbol(
+        &self,
+        symbol: &str,
+        repository_id: &str,
+    ) -> Result<Option<SymbolCommunity>, DomainError> {
+        let graph = self.detect_communities(repository_id).await?;
+        Ok(find_symbol_community(graph.communities, symbol))
+    }
+
+    /// Build the undirected, weighted symbol graph from the repository's call
+    /// graph. Only symbols that participate in at least one caller→callee edge
+    /// become nodes; isolated and anonymous-only symbols are dropped so the
+    /// communities stay meaningful.
+    async fn build_symbol_graph(&self, repository_id: &str) -> Result<SymbolGraph, DomainError> {
+        let references = self.call_graph.find_by_repository(repository_id).await?;
+
+        // Aggregate parallel edges; collect the node set from edge endpoints.
+        let mut edge_weights: HashMap<(String, String), f64> = HashMap::new();
+        let mut language_of: HashMap<String, String> = HashMap::new();
+        let mut node_set: BTreeSet<String> = BTreeSet::new();
+
+        for reference in &references {
+            let Some(caller) = reference.caller_symbol() else {
+                continue; // anonymous / top-level caller — no symbol to attribute
+            };
+            let callee = reference.callee_symbol();
+            if caller == callee {
+                continue; // self-reference / direct recursion — not a community edge
+            }
+
+            let weight = kind_weight(reference.reference_kind().as_str());
+            let lang = reference.language().as_str().to_string();
+            language_of
+                .entry(caller.to_string())
+                .or_insert_with(|| lang.clone());
+            language_of.entry(callee.to_string()).or_insert(lang);
+
+            node_set.insert(caller.to_string());
+            node_set.insert(callee.to_string());
+
+            let key = if caller < callee {
+                (caller.to_string(), callee.to_string())
+            } else {
+                (callee.to_string(), caller.to_string())
+            };
+            *edge_weights.entry(key).or_insert(0.0) += weight;
+        }
+
+        let symbols: Vec<String> = node_set.into_iter().collect();
+        let index_of: HashMap<&str, usize> = symbols
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (s.as_str(), i))
+            .collect();
+
+        // Deterministic edge insertion order.
+        let mut pairs: Vec<((usize, usize), f64)> = edge_weights
+            .iter()
+            .filter_map(|((a, b), &w)| {
+                let ia = *index_of.get(a.as_str())?;
+                let ib = *index_of.get(b.as_str())?;
+                let (lo, hi) = if ia < ib { (ia, ib) } else { (ib, ia) };
+                Some(((lo, hi), w))
+            })
+            .collect();
+        pairs.sort_unstable_by(|x, y| x.0.cmp(&y.0));
+
+        let mut graph = Graph::new(symbols.len());
+        let mut edges: Vec<(usize, usize)> = Vec::with_capacity(pairs.len());
+        for ((lo, hi), w) in pairs {
+            graph.add_edge(lo, hi, w);
+            edges.push((lo, hi));
+        }
+
+        Ok(SymbolGraph {
+            symbols,
+            graph,
+            language_of,
+            edges,
+        })
+    }
+}
+
+/// Pick the most common language among a community's member symbols.
+fn dominant_language(members: &[String], language_of: &HashMap<String, String>) -> String {
+    let mut freq: BTreeMap<&str, usize> = BTreeMap::new();
+    for m in members {
+        if let Some(lang) = language_of.get(m) {
+            *freq.entry(lang.as_str()).or_insert(0) += 1;
+        }
+    }
+    freq.into_iter()
+        .max_by(|a, b| a.1.cmp(&b.1).then(b.0.cmp(a.0)))
+        .map(|(lang, _)| lang.to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Reduce a fully-qualified symbol to its short, undecorated trailing name,
+/// e.g. `pkg/Auth#authenticate().` → `authenticate`.
+fn short_symbol_name(symbol: &str) -> &str {
+    symbol
+        .trim_end_matches(|c: char| matches!(c, '.' | '(' | ')'))
+        .split(|c: char| matches!(c, ':' | '/' | '#' | '.' | '\\'))
+        .filter(|s| !s.is_empty())
+        .next_back()
+        .unwrap_or(symbol)
+}
+
+/// Derive a human-readable community name from its members' symbol names: the
+/// dominant short name if one is shared by >40% of members, otherwise the most
+/// frequent meaningful keyword across all member names.
+fn name_symbol_community(members: &[String]) -> String {
+    if members.is_empty() {
+        return "unknown".to_string();
+    }
+
+    // Dominant short name (>40% of members share it).
+    let mut name_freq: BTreeMap<&str, usize> = BTreeMap::new();
+    for m in members {
+        *name_freq.entry(short_symbol_name(m)).or_insert(0) += 1;
+    }
+    if let Some((&name, &count)) = name_freq
+        .iter()
+        .max_by(|a, b| a.1.cmp(b.1).then(b.0.cmp(a.0)))
+    {
+        // Integer-safe count/len > 0.4  ≡  count * 5 > len * 2.
+        if count * 5 > members.len() * 2 {
+            return slugify(name, NAME_MAX_LENGTH);
+        }
+    }
+
+    // Otherwise the most frequent meaningful keyword.
+    let mut kw_freq: BTreeMap<String, usize> = BTreeMap::new();
+    for m in members {
+        for word in split_identifier(short_symbol_name(m)) {
+            let lower = word.to_lowercase();
+            if lower.len() >= MIN_KEYWORD_LEN && !STOP_WORDS.contains(&lower.as_str()) {
+                *kw_freq.entry(lower).or_insert(0) += 1;
+            }
+        }
+    }
+    let top_kw = kw_freq
+        .iter()
+        .max_by(|a, b| a.1.cmp(b.1).then(b.0.cmp(a.0)))
+        .map(|(k, _)| k.clone())
+        .unwrap_or_default();
+
+    if top_kw.is_empty() {
+        slugify(short_symbol_name(&members[0]), NAME_MAX_LENGTH)
+    } else {
+        slugify(&top_kw, NAME_MAX_LENGTH)
+    }
+}
+
+/// Find the community containing `symbol`, preferring an exact FQN match, then a
+/// boundary suffix match, then a substring match. Case-sensitive throughout.
+fn find_symbol_community(
+    communities: Vec<SymbolCommunity>,
+    symbol: &str,
+) -> Option<SymbolCommunity> {
+    // Exact fully-qualified match.
+    if let Some(c) = communities
+        .iter()
+        .find(|c| c.members.iter().any(|m| m == symbol))
+    {
+        return Some(c.clone());
+    }
+    // Boundary suffix match: the query is the trailing short name of a member.
+    if let Some(c) = communities
+        .iter()
+        .find(|c| c.members.iter().any(|m| short_symbol_name(m) == symbol))
+    {
+        return Some(c.clone());
+    }
+    // Substring fallback.
+    communities
+        .into_iter()
+        .find(|c| c.members.iter().any(|m| m.contains(symbol)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_short_symbol_name() {
+        assert_eq!(
+            short_symbol_name("pkg/Auth#authenticate()."),
+            "authenticate"
+        );
+        assert_eq!(short_symbol_name("crate::module::my_func"), "my_func");
+        assert_eq!(short_symbol_name("Foo\\Bar\\baz"), "baz");
+        assert_eq!(short_symbol_name("plain"), "plain");
+    }
+
+    #[test]
+    fn test_name_symbol_community_dominant_name() {
+        let members = vec![
+            "a/X#handle().".to_string(),
+            "b/Y#handle().".to_string(),
+            "c/Z#handle().".to_string(),
+        ];
+        assert_eq!(name_symbol_community(&members), "handle");
+    }
+
+    #[test]
+    fn test_name_symbol_community_keyword() {
+        let members = vec![
+            "svc/PaymentService#charge().".to_string(),
+            "svc/PaymentGateway#refund().".to_string(),
+            "svc/PaymentRepo#save().".to_string(),
+        ];
+        // No single short name dominates, but "payment" is the shared keyword.
+        assert_eq!(name_symbol_community(&members), "payment");
+    }
+
+    #[test]
+    fn test_find_symbol_community_prefers_exact() {
+        let communities = vec![
+            SymbolCommunity {
+                id: "1".into(),
+                name: "a".into(),
+                repository_id: "r".into(),
+                dominant_language: "rust".into(),
+                size: 1,
+                cohesion: 1.0,
+                members: vec!["pkg/Auth#authenticate().".into()],
+            },
+            SymbolCommunity {
+                id: "2".into(),
+                name: "b".into(),
+                repository_id: "r".into(),
+                dominant_language: "rust".into(),
+                size: 1,
+                cohesion: 1.0,
+                members: vec!["other/authenticate_helper".into()],
+            },
+        ];
+        let hit = find_symbol_community(communities, "pkg/Auth#authenticate().").unwrap();
+        assert_eq!(hit.id, "1");
+    }
+
+    #[test]
+    fn test_find_symbol_community_suffix() {
+        let communities = vec![SymbolCommunity {
+            id: "1".into(),
+            name: "a".into(),
+            repository_id: "r".into(),
+            dominant_language: "rust".into(),
+            size: 1,
+            cohesion: 1.0,
+            members: vec!["pkg/Auth#authenticate().".into()],
+        }];
+        let hit = find_symbol_community(communities, "authenticate").unwrap();
+        assert_eq!(hit.id, "1");
+    }
+}

--- a/src/application/use_cases/symbol_cluster_detection.rs
+++ b/src/application/use_cases/symbol_cluster_detection.rs
@@ -244,6 +244,19 @@ fn short_symbol_name(symbol: &str) -> &str {
         .unwrap_or(symbol)
 }
 
+/// The `Class#method` identifier portion of a symbol — everything after the last
+/// path separator, with trailing call decoration removed. This drops directory
+/// and package-path prefixes (e.g. `svc/`) so keyword-based naming keys on the
+/// type and member names that actually describe a community, not on the shared
+/// path every member happens to live under.
+fn symbol_identifier_part(symbol: &str) -> &str {
+    let trimmed = symbol.trim_end_matches(|c: char| matches!(c, '.' | '(' | ')'));
+    match trimmed.rsplit_once(|c: char| matches!(c, '/' | '\\')) {
+        Some((_, tail)) => tail,
+        None => trimmed,
+    }
+}
+
 /// Derive a human-readable community name from its members' symbol names: the
 /// dominant short name if one is shared by >40% of members, otherwise the most
 /// frequent meaningful keyword across all member names.
@@ -267,13 +280,17 @@ fn name_symbol_community(members: &[String]) -> String {
         }
     }
 
-    // Otherwise the most frequent meaningful keyword.
+    // Otherwise the most frequent meaningful keyword across the type and member
+    // names of each symbol (e.g. `Payment` from `PaymentService#charge`), so a
+    // shared concept beats any single method name.
     let mut kw_freq: BTreeMap<String, usize> = BTreeMap::new();
     for m in members {
-        for word in split_identifier(short_symbol_name(m)) {
-            let lower = word.to_lowercase();
-            if lower.len() >= MIN_KEYWORD_LEN && !STOP_WORDS.contains(&lower.as_str()) {
-                *kw_freq.entry(lower).or_insert(0) += 1;
+        for segment in symbol_identifier_part(m).split(|c: char| matches!(c, ':' | '#' | '.')) {
+            for word in split_identifier(segment) {
+                let lower = word.to_lowercase();
+                if lower.len() >= MIN_KEYWORD_LEN && !STOP_WORDS.contains(&lower.as_str()) {
+                    *kw_freq.entry(lower).or_insert(0) += 1;
+                }
             }
         }
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -111,6 +111,35 @@ pub enum ClustersSubcommand {
     },
 }
 
+/// Subcommands for the `symbol-clusters` command — Leiden communities detected
+/// over the symbol call graph (one level finer than file-level `clusters`).
+#[derive(Subcommand)]
+pub enum SymbolClustersSubcommand {
+    /// List all symbol communities detected in the repository.
+    List {
+        /// Repository ID or name to analyse.
+        repository: String,
+
+        /// Output format: text or json.
+        #[arg(short = 'F', long, value_enum, default_value = "text")]
+        format: OutputFormatTextJson,
+    },
+
+    /// Show the community that a specific symbol belongs to.
+    Get {
+        /// Symbol to look up — a fully-qualified name or a bare short name
+        /// (e.g. `authenticate` or `pkg/Auth#authenticate().`).
+        symbol: String,
+
+        /// Repository ID or name.
+        repository: String,
+
+        /// Output format: text or json.
+        #[arg(short = 'F', long, value_enum, default_value = "text")]
+        format: OutputFormatTextJson,
+    },
+}
+
 /// Initial mode for the interactive TUI.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
 pub enum TuiMode {
@@ -314,6 +343,12 @@ pub enum Commands {
     Clusters {
         #[command(subcommand)]
         subcommand: ClustersSubcommand,
+    },
+
+    /// Detect & query symbol communities (Leiden over the call graph).
+    SymbolClusters {
+        #[command(subcommand)]
+        subcommand: SymbolClustersSubcommand,
     },
 
     /// Start MCP (Model Context Protocol) server for integration with AI tools

--- a/src/connector/adapter/duckdb_call_graph_repository.rs
+++ b/src/connector/adapter/duckdb_call_graph_repository.rs
@@ -592,9 +592,13 @@ impl CallGraphRepository for DuckdbCallGraphRepository {
                 "regexp_matches(caller_symbol, ?)".to_string(),
             )
         } else {
+            // `ESCAPE '\'` lets us treat `_` and `%` inside the symbol name as
+            // literals rather than LIKE wildcards (see `escape_like`). Without
+            // it a snake_case query like `my_func` scans as `my<any>func`,
+            // forcing a near-full table scan of `symbol_references`.
             (
-                "callee_symbol LIKE ?".to_string(),
-                "caller_symbol LIKE ?".to_string(),
+                r"callee_symbol LIKE ? ESCAPE '\'".to_string(),
+                r"caller_symbol LIKE ? ESCAPE '\'".to_string(),
             )
         };
 
@@ -657,7 +661,9 @@ impl CallGraphRepository for DuckdbCallGraphRepository {
         let pattern = if query.is_regex {
             short_name.to_string()
         } else {
-            format!("%{}", short_name)
+            // Leading `%` is the wildcard; the name itself is escaped so its own
+            // `_`/`%`/`\` characters match literally (paired with `ESCAPE '\'`).
+            format!("%{}", escape_like(short_name))
         };
 
         // Params order: pattern (callee leg), extra filters (callee leg),
@@ -731,6 +737,20 @@ impl CallGraphRepository for DuckdbCallGraphRepository {
 ///
 /// This handles both plain symbols (`Home#canDestroy`) and SCIP-style
 /// method descriptors (`Home#canDestroy().`) uniformly.
+/// Escape the LIKE metacharacters (`\`, `%`, `_`) in a literal string so it can
+/// be embedded in a `LIKE ? ESCAPE '\'` pattern and matched verbatim. Backslash
+/// is escaped first so the escapes added for `%`/`_` are not themselves doubled.
+fn escape_like(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if matches!(c, '\\' | '%' | '_') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
 fn scip_boundary_match(symbol: &str, sep: &str, name: &str) -> bool {
     let needle = format!("{}{}", sep, name);
     if let Some(pos) = symbol.rfind(&needle) {
@@ -744,6 +764,16 @@ fn scip_boundary_match(symbol: &str, sep: &str, name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_escape_like_escapes_wildcards() {
+        // `_` and `%` must be backslash-escaped; backslash itself is doubled.
+        assert_eq!(escape_like("my_func"), r"my\_func");
+        assert_eq!(escape_like("a%b"), r"a\%b");
+        assert_eq!(escape_like(r"ns\Type"), r"ns\\Type");
+        // Names without wildcards are returned verbatim.
+        assert_eq!(escape_like("authenticate"), "authenticate");
+    }
 
     async fn create_test_repo() -> DuckdbCallGraphRepository {
         let conn = Connection::open_in_memory().unwrap();

--- a/src/connector/adapter/mcp/server.rs
+++ b/src/connector/adapter/mcp/server.rs
@@ -247,6 +247,24 @@ pub struct ArchitectureOverviewInput {
     pub repository_id: String,
 }
 
+/// Input parameters for the list_symbol_clusters tool
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListSymbolClustersInput {
+    /// Repository ID to detect symbol communities in.
+    pub repository_id: String,
+}
+
+/// Input parameters for the get_symbol_cluster tool
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetSymbolClusterInput {
+    /// Symbol to locate — a fully-qualified name or a bare short name
+    /// (e.g. `authenticate` or `pkg/Auth#authenticate().`).
+    pub symbol: String,
+
+    /// Repository ID the symbol belongs to.
+    pub repository_id: String,
+}
+
 // ── MCP Server ───────────────────────────────────────────────────────────────
 
 /// MCP Server that exposes codesearch functionality
@@ -855,6 +873,60 @@ impl CodesearchMcpServer {
 
         Ok(CallToolResult::success(vec![Content::text(overview)]))
     }
+
+    /// Detect symbol communities in a repository by running Leiden community
+    /// detection over its symbol call graph (one level finer than `list_clusters`,
+    /// which works on files). Returns the communities with their names, dominant
+    /// language, cohesion score, and member symbols — behavioural units that
+    /// frequently cut across files.
+    /// Requires the repository to have been indexed with call-graph support.
+    #[tool(name = "list_symbol_clusters")]
+    async fn list_symbol_clusters(
+        &self,
+        params: Parameters<ListSymbolClustersInput>,
+    ) -> Result<CallToolResult, McpError> {
+        let input = params.0;
+
+        let use_case = self.container.symbol_cluster_detection_use_case();
+        let community_graph = use_case
+            .detect_communities(&input.repository_id)
+            .await
+            .map_err(|e| {
+                McpError::internal_error(format!("Symbol community detection failed: {}", e), None)
+            })?;
+
+        let json = serde_json::to_string_pretty(&community_graph).map_err(|e| {
+            McpError::internal_error(format!("Failed to serialize communities: {}", e), None)
+        })?;
+
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    /// Return the symbol community a specific symbol belongs to. Resolves the
+    /// symbol by exact fully-qualified name, then boundary suffix, then substring.
+    /// Returns `null` when the symbol is not part of any detected community.
+    /// Requires the repository to have been indexed with call-graph support.
+    #[tool(name = "get_symbol_cluster")]
+    async fn get_symbol_cluster(
+        &self,
+        params: Parameters<GetSymbolClusterInput>,
+    ) -> Result<CallToolResult, McpError> {
+        let input = params.0;
+
+        let use_case = self.container.symbol_cluster_detection_use_case();
+        let community = use_case
+            .community_for_symbol(&input.symbol, &input.repository_id)
+            .await
+            .map_err(|e| {
+                McpError::internal_error(format!("Symbol community lookup failed: {}", e), None)
+            })?;
+
+        let json = serde_json::to_string_pretty(&community).map_err(|e| {
+            McpError::internal_error(format!("Failed to serialize community: {}", e), None)
+        })?;
+
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
 }
 
 #[tool_handler]
@@ -877,9 +949,11 @@ impl ServerHandler for CodesearchMcpServer {
                  • get_feature — a single execution feature by entry-point symbol\n\
                  • get_impacted_features — features whose call chain includes changed symbols\n\
                  • file_uses — which files in one repository depend on files in another\n\
-                 • list_clusters — architectural clusters via Leiden community detection\n\
+                 • list_clusters — architectural (file-level) clusters via Leiden community detection\n\
                  • get_file_cluster — the cluster a given file belongs to\n\
-                 • architecture_overview — Markdown table summarising clusters and dependencies"
+                 • architecture_overview — Markdown table summarising clusters and dependencies\n\
+                 • list_symbol_clusters — symbol-level communities via Leiden over the call graph\n\
+                 • get_symbol_cluster — the symbol community a given symbol belongs to"
                     .into(),
             ),
         }

--- a/src/connector/api/container.rs
+++ b/src/connector/api/container.rs
@@ -18,8 +18,8 @@ use crate::{
     FileRelationshipUseCase, ImpactAnalysisUseCase, InMemoryVectorRepository,
     IndexRepositoryUseCase, ListRepositoriesUseCase, LlmQueryExpander, MockEmbedding,
     MockReranking, OpenAiChatClient, OpenAiEmbedding, OpenAiReranking, OrtEmbedding, OrtReranking,
-    RerankingService, Scip, SearchCodeUseCase, SnippetLookupUseCase, SymbolContextUseCase,
-    TreeSitterParser, VectorRepository,
+    RerankingService, Scip, SearchCodeUseCase, SnippetLookupUseCase, SymbolClusterDetectionUseCase,
+    SymbolContextUseCase, TreeSitterParser, VectorRepository,
 };
 
 pub struct ContainerConfig {
@@ -528,6 +528,10 @@ impl Container {
 
     pub fn cluster_detection_use_case(&self) -> ClusterDetectionUseCase {
         ClusterDetectionUseCase::new(Arc::new(self.file_graph_use_case()))
+    }
+
+    pub fn symbol_cluster_detection_use_case(&self) -> SymbolClusterDetectionUseCase {
+        SymbolClusterDetectionUseCase::new(self.call_graph_use_case.clone())
     }
 
     pub fn data_dir(&self) -> &str {

--- a/src/connector/api/controller/mod.rs
+++ b/src/connector/api/controller/mod.rs
@@ -7,6 +7,7 @@ pub mod index_controller;
 pub mod list_repositories_controller;
 pub mod search_controller;
 pub mod stats_controller;
+pub mod symbol_clusters_controller;
 pub mod symbol_context_controller;
 pub mod uses_controller;
 
@@ -19,5 +20,6 @@ pub use index_controller::IndexController;
 pub use list_repositories_controller::ListRepositoriesController;
 pub use search_controller::SearchController;
 pub use stats_controller::StatsController;
+pub use symbol_clusters_controller::SymbolClustersController;
 pub use symbol_context_controller::SymbolContextController;
 pub use uses_controller::UsesController;

--- a/src/connector/api/controller/symbol_clusters_controller.rs
+++ b/src/connector/api/controller/symbol_clusters_controller.rs
@@ -1,0 +1,121 @@
+use anyhow::{Context, Result};
+
+use crate::cli::{OutputFormat, OutputFormatTextJson};
+
+use super::super::Container;
+
+/// CLI controller for symbol-level communities (Leiden over the call graph).
+pub struct SymbolClustersController<'a> {
+    container: &'a Container,
+}
+
+impl<'a> SymbolClustersController<'a> {
+    pub fn new(container: &'a Container) -> Self {
+        Self { container }
+    }
+
+    /// List all symbol communities for the given repository.
+    pub async fn list(&self, repository: String, format: OutputFormatTextJson) -> Result<String> {
+        let use_case = self.container.symbol_cluster_detection_use_case();
+        let graph = use_case
+            .detect_communities(&repository)
+            .await
+            .context("detecting symbol communities for repository")?;
+
+        let format: OutputFormat = format.into();
+        Ok(match format {
+            OutputFormat::Json => {
+                serde_json::to_string_pretty(&graph).context("serializing symbol communities")?
+            }
+            OutputFormat::Vimgrep => {
+                anyhow::bail!("vimgrep output format is not supported for symbol-clusters list")
+            }
+            OutputFormat::Text => {
+                if graph.communities.is_empty() {
+                    return Ok(format!(
+                        "No symbol communities detected for repository `{}` \
+                         (the call graph may be empty — index with SCIP first).",
+                        repository
+                    ));
+                }
+                let mut out = format!(
+                    "Symbol communities for `{}` — {} communities, {} symbols, {} edges\n\
+                     ────────────────────────────────────────────────────────────\n",
+                    repository,
+                    graph.communities.len(),
+                    graph.total_symbols,
+                    graph.total_edges,
+                );
+                for (i, c) in graph.communities.iter().enumerate() {
+                    out.push_str(&format!(
+                        "{:>3}. {} ({} symbols, {}, cohesion {:.2})\n",
+                        i + 1,
+                        c.name,
+                        c.size,
+                        c.dominant_language,
+                        c.cohesion,
+                    ));
+                    for m in c.members.iter().take(5) {
+                        out.push_str(&format!("      {}\n", m));
+                    }
+                    if c.members.len() > 5 {
+                        out.push_str(&format!("      … and {} more\n", c.members.len() - 5));
+                    }
+                }
+                out
+            }
+        })
+    }
+
+    /// Show the community that a specific symbol belongs to.
+    pub async fn get(
+        &self,
+        symbol: String,
+        repository: String,
+        format: OutputFormatTextJson,
+    ) -> Result<String> {
+        let use_case = self.container.symbol_cluster_detection_use_case();
+        let result = use_case
+            .community_for_symbol(&symbol, &repository)
+            .await
+            .context(format!(
+                "finding community for symbol {} in repository {}",
+                symbol, repository
+            ))?;
+
+        let format: OutputFormat = format.into();
+        Ok(match (result, format) {
+            (None, OutputFormat::Json) => serde_json::to_string_pretty(
+                &serde_json::json!({ "symbol": symbol, "community": null, "repository": repository }),
+            )
+            .context("serializing not-found response")?,
+            (None, OutputFormat::Vimgrep) => {
+                anyhow::bail!("vimgrep output format is not supported for symbol-clusters get")
+            }
+            (None, OutputFormat::Text) => format!(
+                "Symbol `{}` was not found in any community for repository `{}`.",
+                symbol, repository
+            ),
+            (Some(c), OutputFormat::Json) => {
+                serde_json::to_string_pretty(&c).context("serializing community")?
+            }
+            (Some(_), OutputFormat::Vimgrep) => {
+                anyhow::bail!("vimgrep output format is not supported for symbol-clusters get")
+            }
+            (Some(c), OutputFormat::Text) => {
+                let mut out = format!(
+                    "Symbol `{}` belongs to community `{}` \
+                     ({} symbols, {}, cohesion {:.2})\n",
+                    symbol, c.name, c.size, c.dominant_language, c.cohesion
+                );
+                for m in c.members.iter().take(20) {
+                    out.push_str(&format!("    {}\n", m));
+                }
+                if c.members.len() > 20 {
+                    out.push_str(&format!("    … and {} more\n", c.members.len() - 20));
+                }
+                out
+            }
+        })
+    }
+}

--- a/src/connector/api/controller/symbol_clusters_controller.rs
+++ b/src/connector/api/controller/symbol_clusters_controller.rs
@@ -84,38 +84,36 @@ impl<'a> SymbolClustersController<'a> {
             ))?;
 
         let format: OutputFormat = format.into();
-        Ok(match (result, format) {
-            (None, OutputFormat::Json) => serde_json::to_string_pretty(
-                &serde_json::json!({ "symbol": symbol, "community": null, "repository": repository }),
-            )
-            .context("serializing not-found response")?,
-            (None, OutputFormat::Vimgrep) => {
+        Ok(match format {
+            // Always serialize the `Option<SymbolCommunity>` (the community on a
+            // hit, `null` on a miss) so `--format json` has one stable schema for
+            // both outcomes, matching the `get_symbol_cluster` MCP tool.
+            OutputFormat::Json => {
+                serde_json::to_string_pretty(&result).context("serializing community")?
+            }
+            OutputFormat::Vimgrep => {
                 anyhow::bail!("vimgrep output format is not supported for symbol-clusters get")
             }
-            (None, OutputFormat::Text) => format!(
-                "Symbol `{}` was not found in any community for repository `{}`.",
-                symbol, repository
-            ),
-            (Some(c), OutputFormat::Json) => {
-                serde_json::to_string_pretty(&c).context("serializing community")?
-            }
-            (Some(_), OutputFormat::Vimgrep) => {
-                anyhow::bail!("vimgrep output format is not supported for symbol-clusters get")
-            }
-            (Some(c), OutputFormat::Text) => {
-                let mut out = format!(
-                    "Symbol `{}` belongs to community `{}` \
-                     ({} symbols, {}, cohesion {:.2})\n",
-                    symbol, c.name, c.size, c.dominant_language, c.cohesion
-                );
-                for m in c.members.iter().take(20) {
-                    out.push_str(&format!("    {}\n", m));
+            OutputFormat::Text => match result {
+                None => format!(
+                    "Symbol `{}` was not found in any community for repository `{}`.",
+                    symbol, repository
+                ),
+                Some(c) => {
+                    let mut out = format!(
+                        "Symbol `{}` belongs to community `{}` \
+                         ({} symbols, {}, cohesion {:.2})\n",
+                        symbol, c.name, c.size, c.dominant_language, c.cohesion
+                    );
+                    for m in c.members.iter().take(20) {
+                        out.push_str(&format!("    {}\n", m));
+                    }
+                    if c.members.len() > 20 {
+                        out.push_str(&format!("    … and {} more\n", c.members.len() - 20));
+                    }
+                    out
                 }
-                if c.members.len() > 20 {
-                    out.push_str(&format!("    … and {} more\n", c.members.len() - 20));
-                }
-                out
-            }
+            },
         })
     }
 }

--- a/src/connector/api/router.rs
+++ b/src/connector/api/router.rs
@@ -1,13 +1,13 @@
 use anyhow::Result;
 
-use crate::cli::ClustersSubcommand;
+use crate::cli::{ClustersSubcommand, SymbolClustersSubcommand};
 use crate::{Commands, FeaturesSubcommand};
 
 use super::container::Container;
 use super::controller::{
     ClustersController, DeleteController, ExecutionFeaturesController, ExplainController,
     ImpactController, IndexController, ListRepositoriesController, SearchController,
-    StatsController, SymbolContextController, UsesController,
+    StatsController, SymbolClustersController, SymbolContextController, UsesController,
 };
 
 pub struct Router<'a> {
@@ -22,6 +22,7 @@ pub struct Router<'a> {
     uses_controller: UsesController<'a>,
     execution_features_controller: ExecutionFeaturesController<'a>,
     clusters_controller: ClustersController<'a>,
+    symbol_clusters_controller: SymbolClustersController<'a>,
 }
 
 impl<'a> Router<'a> {
@@ -38,6 +39,7 @@ impl<'a> Router<'a> {
             uses_controller: UsesController::new(container),
             execution_features_controller: ExecutionFeaturesController::new(container),
             clusters_controller: ClustersController::new(container),
+            symbol_clusters_controller: SymbolClustersController::new(container),
         }
     }
 
@@ -142,6 +144,22 @@ impl<'a> Router<'a> {
                 } => self.clusters_controller.get(file, repository, format).await,
                 ClustersSubcommand::Overview { repository } => {
                     self.clusters_controller.overview(repository).await
+                }
+            },
+            Commands::SymbolClusters { subcommand } => match subcommand {
+                SymbolClustersSubcommand::List { repository, format } => {
+                    self.symbol_clusters_controller
+                        .list(repository, format)
+                        .await
+                }
+                SymbolClustersSubcommand::Get {
+                    symbol,
+                    repository,
+                    format,
+                } => {
+                    self.symbol_clusters_controller
+                        .get(symbol, repository, format)
+                        .await
                 }
             },
             Commands::Mcp { .. } => {

--- a/src/domain/models/cluster.rs
+++ b/src/domain/models/cluster.rs
@@ -33,3 +33,42 @@ pub struct ClusterGraph {
     /// Total number of file-level dependency edges in the underlying graph.
     pub total_edges: usize,
 }
+
+/// A named community of symbols (functions, methods, types) that call or
+/// reference one another tightly — the result of running Leiden on the
+/// **symbol-level** call graph rather than the file-level dependency graph.
+///
+/// Where a [`Cluster`] groups files into architectural modules, a
+/// `SymbolCommunity` groups individual symbols into behavioural units (a feature,
+/// a subsystem, a collaborating set of functions) that can cut across files.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SymbolCommunity {
+    /// UUID identifying this community.
+    pub id: String,
+    /// Human-readable name derived from common tokens in member symbol names.
+    pub name: String,
+    /// Repository this community belongs to.
+    pub repository_id: String,
+    /// Most common programming language among member symbols.
+    pub dominant_language: String,
+    /// Number of member symbols.
+    pub size: usize,
+    /// Ratio of internal edges to all edges touching this community:
+    /// `internal_edges / (internal_edges + external_edges)`.
+    pub cohesion: f32,
+    /// Fully-qualified names of all member symbols, sorted alphabetically.
+    pub members: Vec<String>,
+}
+
+/// The full symbol-community graph for a repository — the result of running
+/// Leiden detection on the symbol-level call graph.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SymbolCommunityGraph {
+    /// All detected communities, sorted by descending size.
+    pub communities: Vec<SymbolCommunity>,
+    pub repository_id: String,
+    /// Total number of symbol nodes in the underlying call graph.
+    pub total_symbols: usize,
+    /// Total number of symbol-level edges in the underlying call graph.
+    pub total_edges: usize,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,12 @@ pub use application::{
     FileRelationshipUseCase, ImpactAnalysis, ImpactAnalysisUseCase, ImpactNode,
     IndexRepositoryUseCase, ListRepositoriesUseCase, MetadataRepository, ParserService,
     QueryExpander, RerankingService, Scip, SearchCodeUseCase, SnippetLookupUseCase,
-    SymbolContext, SymbolContextUseCase, VectorRepository,
+    SymbolClusterDetectionUseCase, SymbolContext, SymbolContextUseCase, VectorRepository,
 };
 
 pub use cli::{
-    Commands, ClustersSubcommand, EmbeddingTarget, FeaturesSubcommand,
-    LlmTarget, OutputFormat, RerankingTarget, TuiMode,
+    ClustersSubcommand, Commands, EmbeddingTarget, FeaturesSubcommand, LlmTarget, OutputFormat,
+    RerankingTarget, SymbolClustersSubcommand, TuiMode,
 };
 
 pub use connector::{
@@ -29,7 +29,8 @@ pub use connector::{
 pub use domain::{
     compute_file_hash, Cluster, ClusterGraph, CodeChunk, DomainError, Embedding, EmbeddingConfig,
     ExecutionFeature, FeatureNode, FileHash, IndexingStatus, Language, NodeType, ReferenceKind,
-    Repository, SearchQuery, SearchResult, SymbolReference, VectorStore,
+    Repository, SearchQuery, SearchResult, SymbolCommunity, SymbolCommunityGraph, SymbolReference,
+    VectorStore,
 };
 
 pub use connector::api::{Container, ContainerConfig, Router};


### PR DESCRIPTION
## Summary

Started as a batch of correctness fixes found while comparing codesearch to a more mature graph tool; now also upgrades the clustering algorithm to genuine Leiden and adds a new symbol-level community-detection feature with a query surface.

> ⚠️ **Not compile-verified in this sandbox.** The full build can't run here because `ort-sys` downloads ONNX binaries from a host blocked by egress policy (`cdn.pyke.io` → 403). `cargo fmt` is clean and the code has been self-reviewed; please run `cargo test` locally before merge.

## 1. Real Leiden (commit 2)

The clustering "Leiden" was Louvain with a pass *labeled* refinement that guaranteed nothing. Replaced with genuine Leiden (Traag et al. 2019):

- **`refine_partition`** rebuilds each community from singletons and re-merges nodes into well-connected sub-communities via a randomized, gain-weighted (`exp(gain/θ)`) choice. This is the step that gives Leiden its two guarantees: internally-connected communities, and escape from the local optima local-moving freezes into.
- **Seeded determinism** — the refinement RNG (a self-contained SplitMix64, no new deps) uses a fixed seed, so results are reproducible across runs *and* processes while keeping the stochastic exploration.
- **Correct multi-level aggregation** — aggregation now collapses the *refined* partition while seeding the next level from the pre-refinement community, and `Graph` carries per-node self-loop mass so intra-community weight is conserved across aggregation levels.
- `split_oversized` + `enforce_connectivity` remain as robustness nets.

## 2. Symbol-level community detection (commit 2)

A dedicated `SymbolClusterDetectionUseCase` runs the *same* Leiden over the **symbol call graph** (`symbol_references`) instead of the file graph — grouping individual functions/methods/types into behavioural communities that cut across files. Graph primitives and naming helpers are shared verbatim with the file-level detector.

**How you query them:**
- `codesearch symbol-clusters list <repo> [-F json]` — every community with size, dominant language, cohesion, and sample members.
- `codesearch symbol-clusters get <symbol> <repo> [-F json]` — the community a symbol belongs to (exact → boundary-suffix → substring match).

New `SymbolCommunity` / `SymbolCommunityGraph` domain models; wired through container, CLI, controller, and router. *(MCP tools for these are a natural fast-follow — not included here to keep the unverified surface small.)*

## 3. Earlier correctness fixes (commit 1)

- Clustering determinism (sorted tie-breaks), connectivity guarantee, and oversized-community split.
- `resolve_symbols` `LIKE` wildcard escaping (`_`/`%` in snake_case names no longer force full scans).
- Impact: stop silently analysing only the alphabetically-first 10 FQNs — `resolve_capped` raises the cap to 100, flags truncation, and warns.
- Docs: removed the stale `impact --depth 5` example.

## Tests

Unit tests added for: clique separation, determinism, community connectivity (the Leiden guarantee), oversized/connectivity post-passes, symbol-graph naming (dominant-name and keyword paths), membership lookup, and `LIKE` escaping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added symbol-level community detection, with new CLI, API, and MCP tool support to list communities or look up a symbol’s community.
  * Expanded architecture analysis docs and README examples for symbol clusters.

* **Bug Fixes**
  * Made clustering results more consistent and reliable, with improved handling of oversized or disconnected communities.
  * Increased symbol resolution limits in impact analysis and added clearer “capped” warnings when results are truncated.
  * Fixed literal matching for symbol suffix searches so special characters are handled correctly.

* **Tests**
  * Added coverage for clustering behavior, determinism, and search escaping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->