### PR TITLE
feat: auto-resolve namespace from git remote metadata

### DIFF
--- a/.claude/skills/codesearch/SKILL.md
+++ b/.claude/skills/codesearch/SKILL.md
@@ -9,22 +9,22 @@ compatibility: Requires the codesearch binary installed and a repository indexed
 
 # Codesearch
 
-Hybrid code search powered by ML embeddings, BM25-style keyword matching, and Reciprocal Rank Fusion. Finds code by meaning **and** by exact keyword — both in a single query, by default.
+Hybrid code search powered by ML embeddings, BM25-style keyword matching, and Reciprocal Rank Fusion. Finds code by meaning and by exact keyword — both in a single query, by default.
 
 ## When to Use This Skill
 
-Invoke this skill **immediately** when:
-- User asks to find code by **intent** (e.g., "where is authentication handled?")
-- User asks to understand **what code does** (e.g., "how does the indexer work?")
-- User asks to explore **functionality** (e.g., "find error handling logic")
-- User asks about **implementation details** (e.g., "how are embeddings generated?")
-- You need to discover code related to a **concept** rather than an exact string
-- User asks about **blast radius** or **impact** of changing a function/symbol
-- User asks **who calls** a function or **what does a function call** (symbol context)
-- User asks for an **explanation** of a symbol's full call flow or business purpose (`explain`)
-- User asks about the **architectural structure** of a repo — modules, clusters, entry-point features
-- User asks which **symbols form a feature/community** together, or which community a symbol belongs to (`symbol-clusters`)
-- User asks **which files one repository uses** from another (cross-repo dependencies)
+Invoke this skill immediately when:
+- User asks to find code by intent (e.g., "where is authentication handled?")
+- User asks to understand what code does (e.g., "how does the indexer work?")
+- User asks to explore functionality (e.g., "find error handling logic")
+- User asks about implementation details (e.g., "how are embeddings generated?")
+- You need to discover code related to a concept rather than an exact string
+- User asks about blast radius or impact of changing a function/symbol
+- User asks who calls a function or what does a function call (symbol context)
+- User asks for an explanation of a symbol's full call flow or business purpose (`explain`)
+- User asks about the architectural structure of a repo — modules, clusters, entry-point features
+- User asks which symbols form a feature/community together, or which community a symbol belongs to (`symbol-clusters`)
+- User asks which files one repository uses from another (cross-repo dependencies)
 
 ## When to Use Built-in Tools Instead
 
@@ -48,7 +48,7 @@ After installation, verify it works:
 codesearch --version
 ```
 
-> **Note:** The script downloads the latest release binary from GitHub for the current OS/architecture. It installs to `$INSTALL_DIR` (defaults to `$HOME/.local/bin` above). Ensure `$HOME/.local/bin` is in your `PATH`. If it's not already in your PATH, add this line to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
+> Note: The script downloads the latest release binary from GitHub for the current OS/architecture. It installs to `$INSTALL_DIR` (defaults to `$HOME/.local/bin` above). Ensure `$HOME/.local/bin` is in your `PATH`. If it's not already in your PATH, add this line to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
 > ```shell
 > export PATH="$HOME/.local/bin:$PATH"
 > ```
@@ -71,7 +71,7 @@ codesearch index /path/to/repo --force
 
 ## Search
 
-Use `codesearch search` to find code. By default it runs **hybrid search** (semantic vector similarity + BM25 keyword matching, fused via RRF) for best precision and recall.
+Use `codesearch search` to find code. By default it runs hybrid search (semantic vector similarity + BM25 keyword matching, fused via RRF) for best precision and recall.
 
 ```shell
 # Hybrid search — default, no flag needed
@@ -108,7 +108,7 @@ codesearch search "config loading" --repository my-project
 
 ### Supported Languages
 
-Codesearch supports: **Rust**, **Python**, **JavaScript**, **TypeScript**, **Go**, **HCL**, **PHP**, **C++**
+Codesearch supports: Rust, Python, JavaScript, TypeScript, Go, HCL, PHP, C++
 
 ### What Gets Indexed
 
@@ -194,7 +194,7 @@ codesearch features impacted authenticate hash_password
 
 ### Clusters — architectural modules (Leiden community detection)
 
-Runs Leiden community detection over the **file** dependency graph to find
+Runs Leiden community detection over the file dependency graph to find
 tightly-coupled groups of files (architectural modules).
 
 ```shell
@@ -210,7 +210,7 @@ codesearch clusters overview my-repo
 
 ### Symbol Clusters — behavioural communities (Leiden over the call graph)
 
-The same Leiden algorithm one level finer: it clusters the **symbol** call graph
+The same Leiden algorithm one level finer: it clusters the symbol call graph
 (functions, methods, types) instead of files, so the communities are
 behavioural units — a feature, a subsystem, a collaborating set of functions —
 that frequently cut across file boundaries. Use file-level `clusters` to answer
@@ -265,7 +265,7 @@ codesearch delete <id-or-path>
 
 ## Query Best Practices
 
-**Do:**
+Do:
 ```shell
 codesearch search "How are file chunks created and stored?"
 codesearch search "Vector embedding generation process"
@@ -273,7 +273,7 @@ codesearch search "Configuration loading and validation"
 codesearch search "HTTP request routing logic"
 ```
 
-**Don't:**
+Don't:
 ```shell
 codesearch search "func"          # Too vague
 codesearch search "error"         # Too generic
@@ -282,22 +282,17 @@ codesearch search "HandleRequest" # Use Grep for exact name matches
 
 ## Recommended Workflow
 
-1. **Start with `codesearch search`** to find relevant code semantically
-2. **Use `Read` tool** to examine the files and lines from search results
-3. **Use `Grep`** only for exact string searches when you know the identifier name
-4. **Use `codesearch search`** again with refined queries if initial results aren't specific enough
+1. Start with `codesearch search` to find relevant code semantically
+2. Use `Read` tool to examine the files and lines from search results
+3. Use `Grep` only for exact string searches when you know the identifier name
+4. Use `codesearch search` again with refined queries if initial results aren't specific enough
 
 ## Namespace Resolution Is Automatic
 
-**Do not pass `--namespace` or the embedding flags (`--embedding-target`,
-`--embedding-model`, `--embedding-dimensions`).** Run commands from inside the
+Do not pass `--namespace` or the embedding flags (`--embedding-target`,
+`--embedding-model`, `--embedding-dimensions`). Run commands from inside the
 repository and codesearch selects the correct namespace and embedding
 configuration on its own.
-
-It works like this: indexing records the repository's git remote; every later
-command matches the current directory against it (by git remote first — so it
-holds across re-clones to a different path — then by on-disk path) and adopts
-that namespace and embedding config automatically.
 
 ```shell
 # Index once (under a custom namespace if you want).
@@ -308,7 +303,7 @@ cd /path/to/repo
 codesearch search "user authentication flow"
 ```
 
-Rely on this. Only set `--namespace` explicitly to **override** the resolved
+Rely on this. Only set `--namespace` explicitly to override the resolved
 value — an explicit flag always wins.
 
 ## Advanced Configuration

--- a/.claude/skills/codesearch/SKILL.md
+++ b/.claude/skills/codesearch/SKILL.md
@@ -287,24 +287,29 @@ codesearch search "HandleRequest" # Use Grep for exact name matches
 3. **Use `Grep`** only for exact string searches when you know the identifier name
 4. **Use `codesearch search`** again with refined queries if initial results aren't specific enough
 
-## Automatic Namespace Resolution
+## Namespace Resolution Is Automatic
 
-You normally **do not** need to pass `--namespace` (or the embedding flags) when
-searching. At index time codesearch records the repository's git remote, and
-every later command run from inside that repository auto-resolves the namespace
-and embedding configuration it was indexed with — matched by git remote first
-(so it survives re-clones to a different path), then by on-disk path.
+**Do not pass `--namespace` or the embedding flags (`--embedding-target`,
+`--embedding-model`, `--embedding-dimensions`).** Run commands from inside the
+repository and codesearch selects the correct namespace and embedding
+configuration on its own.
+
+It works like this: indexing records the repository's git remote; every later
+command matches the current directory against it (by git remote first — so it
+holds across re-clones to a different path — then by on-disk path) and adopts
+that namespace and embedding config automatically.
 
 ```shell
-# Indexed under a custom namespace once…
+# Index once (under a custom namespace if you want).
 codesearch --namespace my-project index /path/to/repo
 
-# …then just search from inside the repo — the namespace is resolved for you.
+# From then on, just run commands inside the repo. No flags.
 cd /path/to/repo
 codesearch search "user authentication flow"
 ```
 
-Pass a flag explicitly to override resolution; it always takes precedence.
+Rely on this. Only set `--namespace` explicitly to **override** the resolved
+value — an explicit flag always wins.
 
 ## Advanced Configuration
 

--- a/.claude/skills/codesearch/SKILL.md
+++ b/.claude/skills/codesearch/SKILL.md
@@ -3,7 +3,7 @@ name: codesearch
 description: Semantic code search using ML embeddings and AST analysis. Replaces built-in search tools for intent-based code exploration. Use when the user asks to find code by describing what it does, understand code relationships, or explore a codebase semantically.
 metadata:
   author: ArtemisMucaj
-  version: "0.7.0"
+  version: "0.8.0"
 compatibility: Requires the codesearch binary installed and a repository indexed with `codesearch index`.
 ---
 
@@ -287,13 +287,32 @@ codesearch search "HandleRequest" # Use Grep for exact name matches
 3. **Use `Grep`** only for exact string searches when you know the identifier name
 4. **Use `codesearch search`** again with refined queries if initial results aren't specific enough
 
+## Automatic Namespace Resolution
+
+You normally **do not** need to pass `--namespace` (or the embedding flags) when
+searching. At index time codesearch records the repository's git remote, and
+every later command run from inside that repository auto-resolves the namespace
+and embedding configuration it was indexed with — matched by git remote first
+(so it survives re-clones to a different path), then by on-disk path.
+
+```shell
+# Indexed under a custom namespace once…
+codesearch --namespace my-project index /path/to/repo
+
+# …then just search from inside the repo — the namespace is resolved for you.
+cd /path/to/repo
+codesearch search "user authentication flow"
+```
+
+Pass a flag explicitly to override resolution; it always takes precedence.
+
 ## Advanced Configuration
 
 ```shell
 # Use a custom data directory for the index
 codesearch --data-dir /custom/path search "query"
 
-# Use a namespace to isolate projects
+# Force a specific namespace (overrides auto-resolution)
 codesearch --namespace my-project search "query"
 
 # Use in-memory storage (no persistence, useful for one-off searches)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,26 @@ cargo build --release
 ./target/release/codesearch
 ```
 
+#### Building in a sandboxed / offline environment
+
+By default the `ort` crate downloads a prebuilt ONNX Runtime binary from
+`cdn.pyke.io` during the build. In a sandboxed or air-gapped environment (e.g. an
+agent runner behind an egress proxy) that download is often blocked, so the build
+fails before any project code is compiled.
+
+When that happens, temporarily enable `ort`'s `load-dynamic` feature so the build
+links nothing and instead `dlopen`s an ONNX Runtime shared library at runtime:
+
+```toml
+# Cargo.toml — for local sandbox builds only; do NOT commit this change
+ort = { version = "2.0.0-rc.9", features = ["ndarray", "load-dynamic"] }
+```
+
+This lets `cargo build`/`cargo check`/`cargo test` compile and run (tests use mock
+embeddings and never touch ONNX). Point `ORT_DYLIB_PATH` at a `libonnxruntime.so`
+if you actually need inference. Revert the feature before committing — it changes
+how release binaries locate ONNX Runtime and must not ship by default.
+
 ### Run
 
 ```bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ syntect = { version = "5", default-features = false, features = ["default-syntax
 
 [dev-dependencies]
 tempfile = "3.10"
+duckdb = { version = "1.4", features = ["bundled"] }
 
 [profile.release]
 lto = true

--- a/docs/features/indexing.md
+++ b/docs/features/indexing.md
@@ -90,7 +90,10 @@ Data is stored using configurable backends:
 - Repository information: ID, name, path, creation/update timestamps
 - Code statistics: chunk count, file count
 - Storage metadata: vector store type, namespace
+- Git remote: a normalised remote URL (e.g. `github.com/owner/repo`) captured from `.git/config` at index time
 - Code chunks: full content, file paths, line numbers, language, node type, symbol names
+
+> The `repositories` and `namespace_config` tables are **global** (one per database file, not namespace-scoped), so each row records which namespace it belongs to. This is what makes [automatic namespace resolution](#automatic-namespace-resolution) a single cheap lookup.
 
 **Vectors** (via `DuckdbVectorRepository` with VSS):
 - Stores `FLOAT[{dimensions}]` embedding vectors directly in DuckDB — the column width is fixed at namespace creation time based on `--embedding-dimensions` (default 384)
@@ -173,6 +176,34 @@ pub struct IndexConfig {
     pub max_chunk_size: usize,
 }
 ```
+
+## Automatic Namespace Resolution
+
+A repository can be indexed under any namespace (DuckDB schema) and with any
+embedding backend/model/dimension. Normally every later command would have to
+repeat those flags (`--namespace`, `--embedding-dimensions`, …) to reach the
+right data. Instead, codesearch resolves them for you.
+
+At index time the repository's **git remote** is normalised (protocol/auth
+stripped, `.git` suffix removed, host lower-cased — so `git@github.com:owner/repo.git`,
+`https://github.com/owner/repo`, and `ssh://git@github.com/owner/repo` all
+collapse to `github.com/owner/repo`) and stored alongside the namespace.
+
+When any command runs, codesearch performs a quick **read-only** lookup against
+the global `repositories` table *before* opening the namespace:
+
+1. Detect the git remote of the current working directory (walking up to the
+   repository root; for `index`, the indexed path is used instead).
+2. Match it against the stored remotes; if there is no remote, fall back to the
+   canonical on-disk path.
+3. On a hit, adopt that repository's namespace and read its embedding
+   target/model/dimensions from `namespace_config`.
+
+Because the git remote is independent of the clone location, this works even
+after a repository is re-cloned to a different directory or machine. Any flag the
+user passes explicitly always wins; resolution only fills in what was left at its
+default. It is skipped entirely under `--memory-storage`, and degrades silently
+to the defaults when the repository has not been indexed.
 
 ## Error Handling
 

--- a/src/application/git_remote.rs
+++ b/src/application/git_remote.rs
@@ -1,0 +1,307 @@
+//! Git remote detection and normalisation.
+//!
+//! Used to attach a stable, portable identifier to each indexed repository.
+//! Unlike the on-disk path (which changes when a repository is cloned to a
+//! different location or machine), the git remote survives clones, so it is the
+//! key used to auto-resolve which namespace a repository was indexed under.
+//!
+//! This module only touches the filesystem (parsing `.git/config`); it performs
+//! no network access and shells out to nothing. It lives in the application
+//! layer alongside the indexing use case, which already reads the filesystem
+//! directly.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Detect the normalised git remote for the repository containing `start`.
+///
+/// Walks up from `start` looking for a `.git` directory (or a `.git` file, as
+/// used by worktrees and submodules), parses its `config`, and returns the
+/// normalised `origin` remote (falling back to the first remote found).
+///
+/// Returns `None` when the path is not inside a git repository, the config has
+/// no remotes, or the remote URL cannot be parsed.
+pub fn detect_remote(start: &Path) -> Option<String> {
+    let config_dir = find_git_config_dir(start)?;
+    let config = fs::read_to_string(config_dir.join("config")).ok()?;
+    let remotes = parse_remote_urls(&config);
+
+    // Prefer `origin`; otherwise take the first remote in declaration order.
+    let chosen = remotes
+        .iter()
+        .find(|(name, _)| name == "origin")
+        .or_else(|| remotes.first())?;
+
+    normalize_remote(&chosen.1)
+}
+
+/// Normalise a git remote URL into a canonical `host/path` form so that the same
+/// repository matches regardless of the protocol used to clone it.
+///
+/// Examples (all normalise to `github.com/owner/repo`):
+/// - `git@github.com:owner/repo.git`
+/// - `https://github.com/owner/repo.git`
+/// - `ssh://git@github.com:22/owner/repo`
+/// - `git://github.com/owner/repo.git`
+///
+/// Returns `None` for an empty input.
+pub fn normalize_remote(raw: &str) -> Option<String> {
+    let s = raw.trim();
+    if s.is_empty() {
+        return None;
+    }
+
+    let has_scheme = s.contains("://");
+
+    // 1. Strip the `scheme://` prefix if present.
+    let after_scheme = match s.split_once("://") {
+        Some((_scheme, rest)) => rest,
+        None => s,
+    };
+
+    // 2. Strip any `user@` / `git@` userinfo.
+    let after_user = match after_scheme.split_once('@') {
+        Some((_user, rest)) => rest,
+        None => after_scheme,
+    };
+
+    // 3. Split host from path. Scheme URLs and `host/path` use `/`; scp-style
+    //    URLs (`git@host:owner/repo`) use the first `:` as the separator.
+    let (host, path) = if has_scheme {
+        after_user.split_once('/').unwrap_or((after_user, ""))
+    } else if let Some(parts) = after_user.split_once(':') {
+        parts
+    } else {
+        after_user.split_once('/').unwrap_or((after_user, ""))
+    };
+
+    // 4. Drop any `:port` suffix from the host and lower-case it (hosts are
+    //    case-insensitive; paths are left untouched).
+    let host = host
+        .split(':')
+        .next()
+        .unwrap_or(host)
+        .trim()
+        .to_ascii_lowercase();
+
+    // 5. Trim surrounding slashes and a trailing `.git` from the path.
+    let path = path.trim().trim_matches('/');
+    let path = path.strip_suffix(".git").unwrap_or(path);
+
+    match (host.is_empty(), path.is_empty()) {
+        (true, true) => None,
+        (false, true) => Some(host),
+        (true, false) => Some(path.to_string()),
+        (false, false) => Some(format!("{host}/{path}")),
+    }
+}
+
+/// Walk up from `start` to locate the directory that holds the git `config`
+/// file for the enclosing repository.
+fn find_git_config_dir(start: &Path) -> Option<PathBuf> {
+    let mut dir = if start.is_dir() {
+        start
+    } else {
+        start.parent()?
+    };
+
+    loop {
+        let git_path = dir.join(".git");
+        if git_path.is_dir() {
+            return Some(resolve_common_config_dir(&git_path));
+        }
+        if git_path.is_file() {
+            // Worktree / submodule: `.git` is a file containing `gitdir: <path>`.
+            if let Some(gitdir) = read_gitdir_file(&git_path, dir) {
+                return Some(resolve_common_config_dir(&gitdir));
+            }
+        }
+        dir = dir.parent()?;
+    }
+}
+
+/// Resolve the directory that actually contains the shared `config` file.
+///
+/// For a linked worktree, `git_dir` is `…/.git/worktrees/<name>` and the
+/// remotes live in the common git directory pointed to by a `commondir` file.
+fn resolve_common_config_dir(git_dir: &Path) -> PathBuf {
+    if let Ok(common) = fs::read_to_string(git_dir.join("commondir")) {
+        let common = common.trim();
+        if !common.is_empty() {
+            let candidate = git_dir.join(common);
+            // Normalise away the `worktrees/<name>/../..` indirection when possible.
+            return candidate.canonicalize().unwrap_or(candidate);
+        }
+    }
+    git_dir.to_path_buf()
+}
+
+/// Parse the `gitdir: <path>` pointer from a `.git` file, resolving relative
+/// paths against `base` (the directory containing the `.git` file).
+fn read_gitdir_file(git_file: &Path, base: &Path) -> Option<PathBuf> {
+    let content = fs::read_to_string(git_file).ok()?;
+    let rest = content.trim().strip_prefix("gitdir:")?.trim();
+    if rest.is_empty() {
+        return None;
+    }
+    let path = Path::new(rest);
+    let resolved = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base.join(path)
+    };
+    Some(resolved.canonicalize().unwrap_or(resolved))
+}
+
+/// Extract `(remote_name, url)` pairs from the contents of a git `config` file,
+/// in declaration order.
+fn parse_remote_urls(config: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let mut current: Option<String> = None;
+
+    for line in config.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            current = parse_remote_section(line);
+        } else if let Some(name) = &current {
+            if let Some((key, value)) = line.split_once('=') {
+                if key.trim().eq_ignore_ascii_case("url") {
+                    out.push((name.clone(), value.trim().to_string()));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Parse a section header, returning the remote name for `[remote "name"]`
+/// headers and `None` for any other section.
+fn parse_remote_section(line: &str) -> Option<String> {
+    let inner = line.strip_prefix('[')?.strip_suffix(']')?.trim();
+    let rest = inner.strip_prefix("remote")?;
+    // Require a separator after `remote` so `[remotefoo]` is not misread.
+    if !rest.starts_with(|c: char| c.is_whitespace() || c == '"') {
+        return None;
+    }
+    let name = rest.trim().trim_matches('"').trim();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_scp_form() {
+        assert_eq!(
+            normalize_remote("git@github.com:owner/repo.git").as_deref(),
+            Some("github.com/owner/repo")
+        );
+    }
+
+    #[test]
+    fn normalizes_https_form() {
+        assert_eq!(
+            normalize_remote("https://github.com/owner/repo.git").as_deref(),
+            Some("github.com/owner/repo")
+        );
+    }
+
+    #[test]
+    fn normalizes_ssh_form_with_port() {
+        assert_eq!(
+            normalize_remote("ssh://git@github.com:22/owner/repo").as_deref(),
+            Some("github.com/owner/repo")
+        );
+    }
+
+    #[test]
+    fn normalizes_git_protocol() {
+        assert_eq!(
+            normalize_remote("git://github.com/owner/repo.git").as_deref(),
+            Some("github.com/owner/repo")
+        );
+    }
+
+    #[test]
+    fn lowercases_host_only() {
+        assert_eq!(
+            normalize_remote("git@GitHub.com:Owner/Repo.git").as_deref(),
+            Some("github.com/Owner/Repo")
+        );
+    }
+
+    #[test]
+    fn all_protocols_agree() {
+        let forms = [
+            "git@github.com:owner/repo.git",
+            "https://github.com/owner/repo.git",
+            "https://github.com/owner/repo",
+            "ssh://git@github.com/owner/repo.git",
+        ];
+        let normalized: Vec<_> = forms.iter().filter_map(|f| normalize_remote(f)).collect();
+        assert!(normalized.iter().all(|n| n == "github.com/owner/repo"));
+        assert_eq!(normalized.len(), forms.len());
+    }
+
+    #[test]
+    fn empty_is_none() {
+        assert_eq!(normalize_remote("   "), None);
+    }
+
+    #[test]
+    fn parses_origin_preferred_over_others() {
+        let config = r#"
+[core]
+    bare = false
+[remote "upstream"]
+    url = https://github.com/upstream/repo.git
+    fetch = +refs/heads/*:refs/remotes/upstream/*
+[remote "origin"]
+    url = git@github.com:owner/repo.git
+    fetch = +refs/heads/*:refs/remotes/origin/*
+[branch "main"]
+    remote = origin
+"#;
+        let remotes = parse_remote_urls(config);
+        assert_eq!(remotes.len(), 2);
+        let origin = remotes.iter().find(|(n, _)| n == "origin").unwrap();
+        assert_eq!(origin.1, "git@github.com:owner/repo.git");
+    }
+
+    #[test]
+    fn ignores_non_remote_sections() {
+        let config = "[remotefoo]\n    url = nope\n[core]\n    url = also-nope\n";
+        assert!(parse_remote_urls(config).is_empty());
+    }
+
+    #[test]
+    fn detect_remote_reads_repo_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let git = dir.path().join(".git");
+        fs::create_dir_all(&git).unwrap();
+        fs::write(
+            git.join("config"),
+            "[remote \"origin\"]\n\turl = git@github.com:owner/repo.git\n",
+        )
+        .unwrap();
+
+        // Detect from a nested subdirectory to exercise the walk-up.
+        let nested = dir.path().join("src").join("inner");
+        fs::create_dir_all(&nested).unwrap();
+        assert_eq!(
+            detect_remote(&nested).as_deref(),
+            Some("github.com/owner/repo")
+        );
+    }
+
+    #[test]
+    fn detect_remote_none_outside_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(detect_remote(dir.path()), None);
+    }
+}

--- a/src/application/interfaces/metadata_repository.rs
+++ b/src/application/interfaces/metadata_repository.rs
@@ -29,4 +29,11 @@ pub trait MetadataRepository: Send + Sync {
         id: &str,
         languages: HashMap<String, LanguageStats>,
     ) -> Result<(), DomainError>;
+
+    /// Update the stored normalised git remote for a repository.
+    async fn update_git_remote(
+        &self,
+        id: &str,
+        git_remote: Option<&str>,
+    ) -> Result<(), DomainError>;
 }

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,3 +1,4 @@
+pub mod git_remote;
 pub mod interfaces;
 pub mod use_cases;
 

--- a/src/application/use_cases/index_repository.rs
+++ b/src/application/use_cases/index_repository.rs
@@ -10,6 +10,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
+use crate::application::git_remote::detect_remote;
 use crate::application::{
     CallGraphUseCase, EmbeddingService, FileHashRepository, MetadataRepository, ParserService,
     VectorRepository,
@@ -212,8 +213,20 @@ impl IndexRepositoryUseCase {
                 .to_string()
         });
 
-        let repository =
-            Repository::new_with_storage(repo_name.clone(), path_str.to_string(), store, namespace);
+        // Capture the git remote (if any) as a stable, clone-independent key so
+        // later commands can auto-resolve this repository's namespace.
+        let git_remote = detect_remote(absolute_path);
+        if let Some(ref remote) = git_remote {
+            debug!("Detected git remote '{}' for {}", remote, repo_name);
+        }
+
+        let repository = Repository::new_with_storage(
+            repo_name.clone(),
+            path_str.to_string(),
+            store,
+            namespace,
+            git_remote,
+        );
         self.repository_repo.save(&repository).await?;
 
         info!("Indexing repository: {} at {}", repo_name, path_str);
@@ -392,6 +405,15 @@ impl IndexRepositoryUseCase {
         repository: &Repository,
     ) -> Result<Repository, DomainError> {
         let start_time = Instant::now();
+
+        // Refresh the stored git remote if it has appeared or changed since the
+        // last index (e.g. a remote was added after the first index).
+        let detected_remote = detect_remote(absolute_path);
+        if detected_remote.is_some() && detected_remote.as_deref() != repository.git_remote() {
+            self.repository_repo
+                .update_git_remote(repository.id(), detected_remote.as_deref())
+                .await?;
+        }
 
         // Load existing file hashes
         let existing_hashes = self

--- a/src/application/use_cases/index_repository.rs
+++ b/src/application/use_cases/index_repository.rs
@@ -406,10 +406,11 @@ impl IndexRepositoryUseCase {
     ) -> Result<Repository, DomainError> {
         let start_time = Instant::now();
 
-        // Refresh the stored git remote if it has appeared or changed since the
-        // last index (e.g. a remote was added after the first index).
+        // Refresh the stored git remote whenever it has changed since the last
+        // index — including when it was removed (None), so a stale remote can't
+        // keep auto-resolving other clones to the wrong namespace.
         let detected_remote = detect_remote(absolute_path);
-        if detected_remote.is_some() && detected_remote.as_deref() != repository.git_remote() {
+        if detected_remote.as_deref() != repository.git_remote() {
             self.repository_repo
                 .update_git_remote(repository.id(), detected_remote.as_deref())
                 .await?;

--- a/src/connector/adapter/duckdb_metadata_repository.rs
+++ b/src/connector/adapter/duckdb_metadata_repository.rs
@@ -87,6 +87,7 @@ impl DuckdbMetadataRepository {
                 file_count BIGINT DEFAULT 0,
                 store TEXT DEFAULT 'duckdb',
                 namespace TEXT,
+                git_remote TEXT,
                 languages TEXT
             );
             "#,
@@ -119,8 +120,8 @@ impl MetadataRepository for DuckdbMetadataRepository {
 
         conn.execute(
             r#"
-            INSERT INTO repositories (id, name, path, created_at, updated_at, chunk_count, file_count, store, namespace, languages)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            INSERT INTO repositories (id, name, path, created_at, updated_at, chunk_count, file_count, store, namespace, git_remote, languages)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
             ON CONFLICT (id) DO UPDATE SET
                 name = excluded.name,
                 path = excluded.path,
@@ -130,6 +131,7 @@ impl MetadataRepository for DuckdbMetadataRepository {
                 file_count = excluded.file_count,
                 store = excluded.store,
                 namespace = excluded.namespace,
+                git_remote = excluded.git_remote,
                 languages = excluded.languages
             "#,
             params![
@@ -142,6 +144,7 @@ impl MetadataRepository for DuckdbMetadataRepository {
                 repository.file_count() as i64,
                 repository.store().as_str(),
                 repository.namespace(),
+                repository.git_remote(),
                 languages_json,
             ],
         )
@@ -154,7 +157,7 @@ impl MetadataRepository for DuckdbMetadataRepository {
         let conn = self.conn.lock().await;
         let mut stmt = conn
             .prepare(
-                "SELECT id, name, path, created_at, updated_at, chunk_count, file_count, store, namespace, languages FROM repositories WHERE id = ?1",
+                "SELECT id, name, path, created_at, updated_at, chunk_count, file_count, store, namespace, git_remote, languages FROM repositories WHERE id = ?1",
             )
             .map_err(|e| DomainError::storage(format!("Failed to prepare statement: {}", e)))?;
 
@@ -163,7 +166,8 @@ impl MetadataRepository for DuckdbMetadataRepository {
                 .get::<_, Option<String>>(7)?
                 .unwrap_or_else(|| "duckdb".to_string());
             let namespace: Option<String> = row.get(8)?;
-            let languages_json: Option<String> = row.get(9)?;
+            let git_remote: Option<String> = row.get(9)?;
+            let languages_json: Option<String> = row.get(10)?;
             Ok(Repository::reconstitute(
                 row.get(0)?,
                 row.get(1)?,
@@ -174,6 +178,7 @@ impl MetadataRepository for DuckdbMetadataRepository {
                 row.get::<_, i64>(6)? as u64,
                 store_str.parse::<VectorStore>().unwrap(),
                 namespace,
+                git_remote,
                 Self::deserialize_languages(languages_json),
             ))
         }) {
@@ -190,7 +195,7 @@ impl MetadataRepository for DuckdbMetadataRepository {
         let conn = self.conn.lock().await;
         let mut stmt = conn
             .prepare(
-                "SELECT id, name, path, created_at, updated_at, chunk_count, file_count, store, namespace, languages FROM repositories WHERE path = ?1",
+                "SELECT id, name, path, created_at, updated_at, chunk_count, file_count, store, namespace, git_remote, languages FROM repositories WHERE path = ?1",
             )
             .map_err(|e| DomainError::storage(format!("Failed to prepare statement: {}", e)))?;
 
@@ -199,7 +204,8 @@ impl MetadataRepository for DuckdbMetadataRepository {
                 .get::<_, Option<String>>(7)?
                 .unwrap_or_else(|| "duckdb".to_string());
             let namespace: Option<String> = row.get(8)?;
-            let languages_json: Option<String> = row.get(9)?;
+            let git_remote: Option<String> = row.get(9)?;
+            let languages_json: Option<String> = row.get(10)?;
             Ok(Repository::reconstitute(
                 row.get(0)?,
                 row.get(1)?,
@@ -210,6 +216,7 @@ impl MetadataRepository for DuckdbMetadataRepository {
                 row.get::<_, i64>(6)? as u64,
                 store_str.parse::<VectorStore>().unwrap(),
                 namespace,
+                git_remote,
                 Self::deserialize_languages(languages_json),
             ))
         }) {
@@ -226,7 +233,7 @@ impl MetadataRepository for DuckdbMetadataRepository {
         let conn = self.conn.lock().await;
         let mut stmt = conn
             .prepare(
-                "SELECT id, name, path, created_at, updated_at, chunk_count, file_count, store, namespace, languages FROM repositories ORDER BY name",
+                "SELECT id, name, path, created_at, updated_at, chunk_count, file_count, store, namespace, git_remote, languages FROM repositories ORDER BY name",
             )
             .map_err(|e| DomainError::storage(format!("Failed to prepare statement: {}", e)))?;
 
@@ -236,7 +243,8 @@ impl MetadataRepository for DuckdbMetadataRepository {
                     .get::<_, Option<String>>(7)?
                     .unwrap_or_else(|| "duckdb".to_string());
                 let namespace: Option<String> = row.get(8)?;
-                let languages_json: Option<String> = row.get(9)?;
+                let git_remote: Option<String> = row.get(9)?;
+                let languages_json: Option<String> = row.get(10)?;
                 Ok(Repository::reconstitute(
                     row.get(0)?,
                     row.get(1)?,
@@ -247,6 +255,7 @@ impl MetadataRepository for DuckdbMetadataRepository {
                     row.get::<_, i64>(6)? as u64,
                     store_str.parse::<VectorStore>().unwrap(),
                     namespace,
+                    git_remote,
                     Self::deserialize_languages(languages_json),
                 ))
             })
@@ -307,6 +316,28 @@ impl MetadataRepository for DuckdbMetadataRepository {
         )
         .map_err(|e| {
             DomainError::storage(format!("Failed to update repository languages: {}", e))
+        })?;
+
+        Ok(())
+    }
+
+    async fn update_git_remote(
+        &self,
+        id: &str,
+        git_remote: Option<&str>,
+    ) -> Result<(), DomainError> {
+        let conn = self.conn.lock().await;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+
+        conn.execute(
+            "UPDATE repositories SET git_remote = ?1, updated_at = ?2 WHERE id = ?3",
+            params![git_remote, now, id],
+        )
+        .map_err(|e| {
+            DomainError::storage(format!("Failed to update repository git remote: {}", e))
         })?;
 
         Ok(())

--- a/src/connector/adapter/duckdb_vector_repository.rs
+++ b/src/connector/adapter/duckdb_vector_repository.rs
@@ -212,6 +212,7 @@ impl DuckdbVectorRepository {
                 file_count BIGINT DEFAULT 0,
                 store TEXT DEFAULT 'duckdb',
                 namespace TEXT,
+                git_remote TEXT,
                 languages TEXT
             );
             CREATE TABLE IF NOT EXISTS namespace_config (

--- a/src/connector/api/container.rs
+++ b/src/connector/api/container.rs
@@ -160,7 +160,7 @@ const READ_ONLY_LOCK_RETRY_INITIAL_MS: u64 = 500;
 
 /// Returns `true` when the error string looks like a DuckDB file-lock conflict
 /// produced by a concurrent writer process.
-fn is_lock_conflict(err: &str) -> bool {
+pub(crate) fn is_lock_conflict(err: &str) -> bool {
     err.contains("Could not set lock on file") || err.contains("Conflicting lock is held")
 }
 

--- a/src/connector/api/mod.rs
+++ b/src/connector/api/mod.rs
@@ -1,6 +1,8 @@
 pub mod container;
 pub mod controller;
+pub mod repo_resolver;
 pub mod router;
 
 pub use container::{Container, ContainerConfig};
+pub use repo_resolver::{resolve as resolve_repo_context, ResolvedContext};
 pub use router::Router;

--- a/src/connector/api/repo_resolver.rs
+++ b/src/connector/api/repo_resolver.rs
@@ -10,11 +10,24 @@
 //! back to the canonical on-disk path.
 
 use std::path::{Path, PathBuf};
+use std::thread::sleep;
+use std::time::Duration;
 
 use duckdb::{params, AccessMode, Config, Connection};
 use tracing::debug;
 
 use crate::application::git_remote::detect_remote;
+use crate::connector::api::container::is_lock_conflict;
+
+/// Maximum number of retry attempts when the read-only open is blocked by a
+/// concurrent writer (e.g. an in-progress `codesearch index`). Mirrors the
+/// retry budget used when the container itself opens the database read-only, so
+/// resolution lands on the right namespace instead of silently falling back to
+/// the default once the writer releases the lock.
+const LOCK_RETRIES: u32 = 5;
+
+/// Initial backoff for lock-conflict retries; doubles each attempt.
+const LOCK_RETRY_INITIAL_MS: u64 = 500;
 
 /// The indexing context resolved for a working directory.
 #[derive(Debug, Clone)]
@@ -44,13 +57,7 @@ pub fn resolve(db_path: &Path, repo_root: &Path) -> Option<ResolvedContext> {
         return None;
     }
 
-    let conn = match open_read_only(db_path) {
-        Ok(conn) => conn,
-        Err(e) => {
-            debug!("repo resolver: could not open {}: {}", db_path.display(), e);
-            return None;
-        }
-    };
+    let conn = open_read_only_with_retry(db_path)?;
 
     // Prefer the git remote; fall back to the canonical path.
     let remote = detect_remote(repo_root);
@@ -79,6 +86,32 @@ pub fn resolve(db_path: &Path, repo_root: &Path) -> Option<ResolvedContext> {
 fn open_read_only(db_path: &Path) -> Result<Connection, duckdb::Error> {
     let config = Config::default().access_mode(AccessMode::ReadOnly)?;
     Connection::open_with_flags(db_path, config)
+}
+
+/// Open the database read-only, retrying with exponential backoff while a
+/// concurrent writer holds the lock. Non-lock failures (e.g. the database does
+/// not exist yet) return `None` immediately. A persistent lock after all
+/// retries also yields `None` — the container open that follows runs its own
+/// retry and will surface a clear error to the user.
+fn open_read_only_with_retry(db_path: &Path) -> Option<Connection> {
+    let mut delay_ms = LOCK_RETRY_INITIAL_MS;
+    for attempt in 0..=LOCK_RETRIES {
+        match open_read_only(db_path) {
+            Ok(conn) => return Some(conn),
+            Err(e) if attempt < LOCK_RETRIES && is_lock_conflict(&e.to_string()) => {
+                if attempt == 0 {
+                    debug!("repo resolver: database locked by another process; waiting…");
+                }
+                sleep(Duration::from_millis(delay_ms));
+                delay_ms *= 2;
+            }
+            Err(e) => {
+                debug!("repo resolver: could not open {}: {}", db_path.display(), e);
+                return None;
+            }
+        }
+    }
+    None
 }
 
 fn canonical(path: &Path) -> Option<PathBuf> {

--- a/src/connector/api/repo_resolver.rs
+++ b/src/connector/api/repo_resolver.rs
@@ -1,0 +1,136 @@
+//! Auto-resolution of a repository's indexing context from the global metadata.
+//!
+//! The `repositories` and `namespace_config` tables are global (one per DuckDB
+//! file, not namespace-scoped), so a single read-only query can map a working
+//! directory to the namespace it was indexed under — and to the embedding
+//! configuration that namespace requires — without the caller having to know
+//! either up front.
+//!
+//! Matching prefers the git remote (a stable, clone-independent key) and falls
+//! back to the canonical on-disk path.
+
+use std::path::{Path, PathBuf};
+
+use duckdb::{params, AccessMode, Config, Connection};
+use tracing::debug;
+
+use crate::application::git_remote::detect_remote;
+
+/// The indexing context resolved for a working directory.
+#[derive(Debug, Clone)]
+pub struct ResolvedContext {
+    /// Namespace the repository was indexed under.
+    pub namespace: String,
+    /// Embedding backend recorded for that namespace (`"onnx"` / `"api"`).
+    pub embedding_target: Option<String>,
+    /// Embedding model recorded for that namespace.
+    pub embedding_model: Option<String>,
+    /// Embedding dimensionality recorded for that namespace.
+    pub embedding_dimensions: Option<usize>,
+    /// Human-readable repository name (for log messages).
+    pub repository_name: String,
+    /// How the repository was matched: `"git remote"` or `"path"`.
+    pub matched_by: &'static str,
+}
+
+/// Resolve the indexing context for `repo_root` from the database at `db_path`.
+///
+/// Returns `None` when the database does not exist, the repository has not been
+/// indexed, or it carries no namespace. All failures degrade to `None` so the
+/// caller can simply fall back to defaults — resolution is a convenience, never
+/// a hard requirement.
+pub fn resolve(db_path: &Path, repo_root: &Path) -> Option<ResolvedContext> {
+    if !db_path.exists() {
+        return None;
+    }
+
+    let conn = match open_read_only(db_path) {
+        Ok(conn) => conn,
+        Err(e) => {
+            debug!("repo resolver: could not open {}: {}", db_path.display(), e);
+            return None;
+        }
+    };
+
+    // Prefer the git remote; fall back to the canonical path.
+    let remote = detect_remote(repo_root);
+    let (namespace, repository_name, matched_by) = remote
+        .as_deref()
+        .and_then(|r| find_by_remote(&conn, r).map(|(ns, name)| (ns, name, "git remote")))
+        .or_else(|| {
+            canonical(repo_root)
+                .and_then(|p| find_by_path(&conn, &p))
+                .map(|(ns, name)| (ns, name, "path"))
+        })?;
+
+    let (embedding_target, embedding_model, embedding_dimensions) =
+        find_namespace_config(&conn, &namespace).unwrap_or((None, None, None));
+
+    Some(ResolvedContext {
+        namespace,
+        embedding_target,
+        embedding_model,
+        embedding_dimensions,
+        repository_name,
+        matched_by,
+    })
+}
+
+fn open_read_only(db_path: &Path) -> Result<Connection, duckdb::Error> {
+    let config = Config::default().access_mode(AccessMode::ReadOnly)?;
+    Connection::open_with_flags(db_path, config)
+}
+
+fn canonical(path: &Path) -> Option<PathBuf> {
+    std::fs::canonicalize(path).ok()
+}
+
+/// Find the namespace + name for a repository by its normalised git remote.
+/// When several repositories share a remote, the most recently updated wins.
+fn find_by_remote(conn: &Connection, remote: &str) -> Option<(String, String)> {
+    query_repo(
+        conn,
+        "SELECT namespace, name FROM repositories \
+         WHERE git_remote = ?1 AND namespace IS NOT NULL \
+         ORDER BY updated_at DESC LIMIT 1",
+        remote,
+    )
+}
+
+/// Find the namespace + name for a repository by its canonical path.
+fn find_by_path(conn: &Connection, path: &Path) -> Option<(String, String)> {
+    query_repo(
+        conn,
+        "SELECT namespace, name FROM repositories \
+         WHERE path = ?1 AND namespace IS NOT NULL LIMIT 1",
+        &path.to_string_lossy(),
+    )
+}
+
+fn query_repo(conn: &Connection, sql: &str, key: &str) -> Option<(String, String)> {
+    let mut stmt = conn.prepare(sql).ok()?;
+    stmt.query_row(params![key], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })
+    .ok()
+}
+
+#[allow(clippy::type_complexity)]
+fn find_namespace_config(
+    conn: &Connection,
+    namespace: &str,
+) -> Option<(Option<String>, Option<String>, Option<usize>)> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT embedding_target, embedding_model, dimensions \
+             FROM namespace_config WHERE namespace = ?1",
+        )
+        .ok()?;
+    stmt.query_row(params![namespace], |row| {
+        let target: String = row.get(0)?;
+        let model: String = row.get(1)?;
+        let dims: i64 = row.get(2)?;
+        Ok((Some(target), Some(model), Some(dims as usize)))
+    })
+    .ok()
+}

--- a/src/domain/models/repository.rs
+++ b/src/domain/models/repository.rs
@@ -69,6 +69,11 @@ pub struct Repository {
     store: VectorStore,
     /// Namespace for vector storage (DuckDB schema or ChromaDB collection).
     namespace: Option<String>,
+    /// Normalised git remote (e.g. `github.com/owner/repo`), when the indexed
+    /// path is a git repository. Used as a stable, portable key to resolve which
+    /// namespace this repository was indexed under, regardless of clone path.
+    #[serde(default)]
+    git_remote: Option<String>,
     /// Language statistics (language name -> stats).
     #[serde(default)]
     languages: HashMap<String, LanguageStats>,
@@ -87,6 +92,7 @@ impl Repository {
             file_count: 0,
             store: VectorStore::default(),
             namespace: None,
+            git_remote: None,
             languages: HashMap::new(),
         }
     }
@@ -96,6 +102,7 @@ impl Repository {
         path: String,
         store: VectorStore,
         namespace: Option<String>,
+        git_remote: Option<String>,
     ) -> Self {
         let now = current_timestamp();
         Self {
@@ -108,6 +115,7 @@ impl Repository {
             file_count: 0,
             store,
             namespace,
+            git_remote,
             languages: HashMap::new(),
         }
     }
@@ -124,6 +132,7 @@ impl Repository {
         file_count: u64,
         store: VectorStore,
         namespace: Option<String>,
+        git_remote: Option<String>,
         languages: HashMap<String, LanguageStats>,
     ) -> Self {
         Self {
@@ -136,6 +145,7 @@ impl Repository {
             file_count,
             store,
             namespace,
+            git_remote,
             languages,
         }
     }
@@ -174,6 +184,14 @@ impl Repository {
 
     pub fn namespace(&self) -> Option<&str> {
         self.namespace.as_deref()
+    }
+
+    pub fn git_remote(&self) -> Option<&str> {
+        self.git_remote.as_deref()
+    }
+
+    pub fn set_git_remote(&mut self, git_remote: Option<String>) {
+        self.git_remote = git_remote;
     }
 
     pub fn languages(&self) -> &HashMap<String, LanguageStats> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,4 +37,6 @@ pub use domain::{
 
 pub use domain::{CommunityMeta, GraphEdge, GraphLevel, GraphNode, GraphView};
 
-pub use connector::api::{Container, ContainerConfig, Router};
+pub use connector::api::{
+    resolve_repo_context, Container, ContainerConfig, ResolvedContext, Router,
+};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use clap::Parser;
+use clap::{CommandFactory, FromArgMatches, Parser};
 use rmcp::ServiceExt;
 use tracing_subscriber::EnvFilter;
 
@@ -92,7 +92,10 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let cli = Cli::parse();
+    // Parse via ArgMatches so we can tell which global flags the user actually
+    // supplied (vs. their default values) and only auto-resolve the rest.
+    let matches = Cli::command().get_matches();
+    let cli = Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit());
 
     // Extract MCP mode info before moving cli.command
     let (is_mcp, http_port, public_bind) = match &cli.command {
@@ -153,6 +156,52 @@ async fn main() -> Result<()> {
     let data_dir = expand_tilde(&cli.data_dir);
     std::fs::create_dir_all(&data_dir)?;
 
+    // Auto-resolve the namespace and embedding configuration from the indexed
+    // metadata so commands run from inside a repository "just work" without the
+    // user re-specifying the flags used at index time. Only kicks in when the
+    // user did not pin a namespace explicitly and is not using in-memory storage.
+    let mut namespace = cli.namespace.clone();
+    let mut embedding_target = cli.embedding_target;
+    let mut embedding_model = cli.embedding_model.clone();
+    let mut embedding_dimensions = cli.embedding_dimensions;
+
+    if !cli.memory_storage && !flag_set(&matches, "namespace") {
+        let repo_root = match &cli.command {
+            Commands::Index { path, .. } => std::fs::canonicalize(path).ok(),
+            _ => std::env::current_dir().ok(),
+        };
+        if let Some(root) = repo_root {
+            let db_path = std::path::Path::new(&data_dir).join("codesearch.duckdb");
+            if let Some(ctx) = codesearch::resolve_repo_context(&db_path, &root) {
+                namespace = ctx.namespace.clone();
+
+                if !flag_set(&matches, "embedding_target") {
+                    if let Some(target) = ctx.embedding_target.as_deref() {
+                        embedding_target = match target {
+                            "api" => EmbeddingTarget::Api,
+                            _ => EmbeddingTarget::Onnx,
+                        };
+                    }
+                }
+                if !flag_set(&matches, "embedding_model") && ctx.embedding_model.is_some() {
+                    embedding_model = ctx.embedding_model.clone();
+                }
+                if !flag_set(&matches, "embedding_dimensions") {
+                    if let Some(dims) = ctx.embedding_dimensions {
+                        embedding_dimensions = dims;
+                    }
+                }
+
+                tracing::info!(
+                    "Auto-selected namespace '{}' (matched by {} for '{}') from indexed metadata",
+                    namespace,
+                    ctx.matched_by,
+                    ctx.repository_name
+                );
+            }
+        }
+    }
+
     // Read-only mode for commands that never write to the database.
     // This avoids acquiring DuckDB's exclusive write lock, allowing multiple
     // codesearch processes (e.g. concurrent searches) to run simultaneously.
@@ -174,13 +223,13 @@ async fn main() -> Result<()> {
     let config = ContainerConfig {
         data_dir,
         mock_embeddings: cli.mock_embeddings,
-        namespace: cli.namespace,
+        namespace,
         memory_storage: cli.memory_storage,
         no_rerank: cli.no_rerank,
         expand_query: cli.expand_query,
-        embedding_target: cli.embedding_target,
-        embedding_model: cli.embedding_model,
-        embedding_dimensions: cli.embedding_dimensions,
+        embedding_target,
+        embedding_model,
+        embedding_dimensions,
         reranking_target: cli.reranking_target,
         llm_target: cli.llm_target,
         parse_concurrency: cli.embedding_requests,
@@ -312,6 +361,23 @@ async fn run_http_server(container: Arc<Container>, port: u16, public: bool) -> 
         .await?;
 
     Ok(())
+}
+
+/// Whether a (possibly global) argument was supplied on the command line, as
+/// opposed to falling back to its default value. Walks into the matched
+/// subcommand because global args may be recorded at either level.
+fn flag_set(matches: &clap::ArgMatches, id: &str) -> bool {
+    use clap::parser::ValueSource;
+    fn walk(m: &clap::ArgMatches, id: &str) -> bool {
+        if matches!(m.value_source(id), Some(ValueSource::CommandLine)) {
+            return true;
+        }
+        match m.subcommand() {
+            Some((_, sub)) => walk(sub, id),
+            None => false,
+        }
+    }
+    walk(matches, id)
 }
 
 fn expand_tilde(path: &str) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,14 +158,18 @@ async fn main() -> Result<()> {
 
     // Auto-resolve the namespace and embedding configuration from the indexed
     // metadata so commands run from inside a repository "just work" without the
-    // user re-specifying the flags used at index time. Only kicks in when the
-    // user did not pin a namespace explicitly and is not using in-memory storage.
+    // user re-specifying the flags used at index time. We always resolve (unless
+    // in-memory) and adopt the namespace only when it was not pinned explicitly;
+    // the embedding settings are adopted only when the effective namespace
+    // matches the resolved one, so an explicit `--namespace <indexed-ns>` still
+    // picks up that namespace's embedding config (which `Container::new`
+    // validates) instead of silently falling back to the ONNX/384 defaults.
     let mut namespace = cli.namespace.clone();
     let mut embedding_target = cli.embedding_target;
     let mut embedding_model = cli.embedding_model.clone();
     let mut embedding_dimensions = cli.embedding_dimensions;
 
-    if !cli.memory_storage && !flag_set(&matches, "namespace") {
+    if !cli.memory_storage {
         let repo_root = match &cli.command {
             Commands::Index { path, .. } => std::fs::canonicalize(path).ok(),
             _ => std::env::current_dir().ok(),
@@ -173,31 +177,37 @@ async fn main() -> Result<()> {
         if let Some(root) = repo_root {
             let db_path = std::path::Path::new(&data_dir).join("codesearch.duckdb");
             if let Some(ctx) = codesearch::resolve_repo_context(&db_path, &root) {
-                namespace = ctx.namespace.clone();
-
-                if !flag_set(&matches, "embedding_target") {
-                    if let Some(target) = ctx.embedding_target.as_deref() {
-                        embedding_target = match target {
-                            "api" => EmbeddingTarget::Api,
-                            _ => EmbeddingTarget::Onnx,
-                        };
-                    }
-                }
-                if !flag_set(&matches, "embedding_model") && ctx.embedding_model.is_some() {
-                    embedding_model = ctx.embedding_model.clone();
-                }
-                if !flag_set(&matches, "embedding_dimensions") {
-                    if let Some(dims) = ctx.embedding_dimensions {
-                        embedding_dimensions = dims;
-                    }
+                if !flag_set(&matches, "namespace") {
+                    namespace = ctx.namespace.clone();
                 }
 
-                tracing::info!(
-                    "Auto-selected namespace '{}' (matched by {} for '{}') from indexed metadata",
-                    namespace,
-                    ctx.matched_by,
-                    ctx.repository_name
-                );
+                // Only adopt the resolved embedding config when it actually
+                // describes the namespace we are about to open.
+                if namespace == ctx.namespace {
+                    if !flag_set(&matches, "embedding_target") {
+                        if let Some(target) = ctx.embedding_target.as_deref() {
+                            embedding_target = match target {
+                                "api" => EmbeddingTarget::Api,
+                                _ => EmbeddingTarget::Onnx,
+                            };
+                        }
+                    }
+                    if !flag_set(&matches, "embedding_model") && ctx.embedding_model.is_some() {
+                        embedding_model = ctx.embedding_model.clone();
+                    }
+                    if !flag_set(&matches, "embedding_dimensions") {
+                        if let Some(dims) = ctx.embedding_dimensions {
+                            embedding_dimensions = dims;
+                        }
+                    }
+
+                    tracing::info!(
+                        "Using namespace '{}' (matched by {} for '{}') from indexed metadata",
+                        namespace,
+                        ctx.matched_by,
+                        ctx.repository_name
+                    );
+                }
             }
         }
     }

--- a/tests/repo_resolver_tests.rs
+++ b/tests/repo_resolver_tests.rs
@@ -1,0 +1,149 @@
+//! End-to-end tests for git-remote-based namespace resolution.
+//!
+//! These exercise the path from "a repository was indexed under namespace X with
+//! embedding config Y" to "running a command from inside that repository
+//! resolves X and Y automatically" — keyed by git remote, with a canonical-path
+//! fallback.
+//!
+//! The `repositories` and `namespace_config` tables are seeded with a plain
+//! DuckDB connection (matching the production schema) so the test exercises the
+//! read-only resolver without pulling in the `vss`/`fts` extensions that the
+//! full vector repository loads.
+
+use std::fs;
+use std::path::Path;
+
+use codesearch::resolve_repo_context;
+use duckdb::{params, Connection};
+
+/// Seed a fresh DuckDB file with one repository row (and matching namespace
+/// config), then drop the connection so the read-only resolver can open it.
+#[allow(clippy::too_many_arguments)]
+fn seed_db(
+    db_path: &Path,
+    namespace: &str,
+    repo_path: &str,
+    git_remote: Option<&str>,
+    embedding_target: &str,
+    embedding_model: &str,
+    dimensions: i64,
+) {
+    let conn = Connection::open(db_path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE repositories (
+            id TEXT PRIMARY KEY, name TEXT, path TEXT, created_at BIGINT, updated_at BIGINT,
+            chunk_count BIGINT, file_count BIGINT, store TEXT, namespace TEXT,
+            git_remote TEXT, languages TEXT
+        );
+        CREATE TABLE namespace_config (
+            namespace TEXT PRIMARY KEY, embedding_target TEXT, embedding_model TEXT,
+            dimensions INTEGER
+        );",
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO repositories
+            (id, name, path, created_at, updated_at, chunk_count, file_count, store, namespace, git_remote, languages)
+         VALUES (?1, 'demo', ?2, 1, 1, 1, 1, 'duckdb', ?3, ?4, NULL)",
+        params!["id-1", repo_path, namespace, git_remote],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO namespace_config VALUES (?1, ?2, ?3, ?4)",
+        params![namespace, embedding_target, embedding_model, dimensions],
+    )
+    .unwrap();
+    // `conn` drops here, releasing the database lock.
+}
+
+fn write_git_remote(repo_dir: &Path, url: &str) {
+    let git = repo_dir.join(".git");
+    fs::create_dir_all(&git).unwrap();
+    fs::write(
+        git.join("config"),
+        format!("[remote \"origin\"]\n\turl = {url}\n"),
+    )
+    .unwrap();
+}
+
+#[test]
+fn resolves_namespace_and_embedding_config_by_git_remote() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let repo_dir = tempfile::tempdir().unwrap();
+    let db_path = data_dir.path().join("codesearch.duckdb");
+
+    let canonical = fs::canonicalize(repo_dir.path()).unwrap();
+    seed_db(
+        &db_path,
+        "my-namespace",
+        &canonical.to_string_lossy(),
+        Some("github.com/owner/demo"),
+        "onnx",
+        "sentence-transformers/all-MiniLM-L6-v2",
+        384,
+    );
+
+    // A clone at a *different* path still resolves via the git remote.
+    let clone_dir = tempfile::tempdir().unwrap();
+    write_git_remote(clone_dir.path(), "git@github.com:owner/demo.git");
+
+    let ctx = resolve_repo_context(&db_path, clone_dir.path()).expect("should resolve");
+    assert_eq!(ctx.namespace, "my-namespace");
+    assert_eq!(ctx.matched_by, "git remote");
+    assert_eq!(ctx.embedding_target.as_deref(), Some("onnx"));
+    assert_eq!(ctx.embedding_dimensions, Some(384));
+}
+
+#[test]
+fn resolves_namespace_by_path_when_no_remote() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let repo_dir = tempfile::tempdir().unwrap();
+    let db_path = data_dir.path().join("codesearch.duckdb");
+
+    let canonical = fs::canonicalize(repo_dir.path()).unwrap();
+    seed_db(
+        &db_path,
+        "path-namespace",
+        &canonical.to_string_lossy(),
+        None,
+        "onnx",
+        "model",
+        768,
+    );
+
+    // No .git in repo_dir → falls back to canonical-path matching.
+    let ctx = resolve_repo_context(&db_path, repo_dir.path()).expect("should resolve by path");
+    assert_eq!(ctx.namespace, "path-namespace");
+    assert_eq!(ctx.matched_by, "path");
+    assert_eq!(ctx.embedding_dimensions, Some(768));
+}
+
+#[test]
+fn returns_none_for_unknown_repository() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let indexed = tempfile::tempdir().unwrap();
+    let db_path = data_dir.path().join("codesearch.duckdb");
+
+    let canonical = fs::canonicalize(indexed.path()).unwrap();
+    seed_db(
+        &db_path,
+        "ns",
+        &canonical.to_string_lossy(),
+        Some("github.com/owner/indexed"),
+        "onnx",
+        "model",
+        384,
+    );
+
+    // A different, unindexed repository with an unrelated remote.
+    let other = tempfile::tempdir().unwrap();
+    write_git_remote(other.path(), "https://github.com/someone/else.git");
+    assert!(resolve_repo_context(&db_path, other.path()).is_none());
+}
+
+#[test]
+fn returns_none_when_database_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("does-not-exist.duckdb");
+    assert!(resolve_repo_context(&missing, dir.path()).is_none());
+}


### PR DESCRIPTION
Store each indexed repository's normalised git remote (e.g.
github.com/owner/repo) and use it to auto-select the namespace and
embedding configuration the repository was indexed with, so commands run
from inside a repository "just work" without re-passing global flags.

Because the global `repositories` and `namespace_config` tables are not
namespace-scoped, a single read-only lookup maps the working directory to
its namespace and embedding target/model/dimensions before the namespace
is opened. Matching prefers the git remote (stable across re-clones to a
different path or machine) and falls back to the canonical on-disk path.
Any flag the user passes explicitly still wins; resolution only fills in
defaults and is skipped under --memory-storage.

- domain: add git_remote to Repository
- application: git_remote detection/normalisation helper; capture it on
  first index and refresh on incremental index
- connector: git_remote column + update_git_remote; read-only repo_resolver
- cli: detect explicitly-set flags and apply resolved context in main
- tests: remote normalisation + end-to-end resolver round-trip
- docs: indexing doc, skill, and a sandbox-build note in AGENTS.md

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JFNFW51B4PQwppjqjgMbSa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic repository context detection, so namespace and embedding settings can now be inferred from previously indexed repository metadata.
  * Git remote information is now captured during indexing and used to match repositories more reliably.

* **Bug Fixes**
  * Improved handling for repositories without a stored remote or with changed remote settings.
  * Explicit CLI options still override any automatically resolved values.

* **Documentation**
  * Updated setup and indexing docs with the new resolution behavior and offline/sandbox build guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->