### PR TITLE
feat: default ONNX and LLM models to Qwen3 family

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ CodeSearch supports optional reranking to improve search result relevance using 
 
 1. Initial hybrid/vector search retrieves candidates using inverse-log scaling: `num + ⌈num / ln(num)⌉` (defaults to 20 base candidates when `num ≤ 10`)
 2. For semantic-only results, candidates with vector similarity score below 0.1 are excluded (too irrelevant to benefit from reranking); hybrid RRF results bypass this filter because RRF scores are intentionally small (~0.016–0.033)
-3. A cross-encoder model (bge-reranker-base) reranks remaining candidates based on query-document relevance
+3. A cross-encoder model (Qwen3-Reranker-0.6B) reranks remaining candidates based on query-document relevance
 4. Top `num` reranked results are returned
 
 ### Usage
@@ -503,7 +503,7 @@ codesearch search "validation" --language rust --min-score 0.7
 
 ### Models
 
-- **Default**: `BAAI/bge-reranker-base` (110M parameters, ONNX)
+- **Default**: `Qwen/Qwen3-Reranker-0.6B` (600M parameters, ONNX)
 - Downloaded automatically from HuggingFace Hub on first use
 - No API key or external service required
 

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ CodeSearch supports optional reranking to improve search result relevance using 
 
 1. Initial hybrid/vector search retrieves candidates using inverse-log scaling: `num + ⌈num / ln(num)⌉` (defaults to 20 base candidates when `num ≤ 10`)
 2. For semantic-only results, candidates with vector similarity score below 0.1 are excluded (too irrelevant to benefit from reranking); hybrid RRF results bypass this filter because RRF scores are intentionally small (~0.016–0.033)
-3. A cross-encoder model (Qwen3-Reranker-0.6B) reranks remaining candidates based on query-document relevance
+3. A causal reranker (Qwen3-Reranker-0.6B) reranks remaining candidates based on query-document relevance
 4. Top `num` reranked results are returned
 
 ### Usage

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -126,7 +126,7 @@ flowchart TB
     D --> E[DuckDB]
 
     C -.- C1[TreeSitterParser<br/>Extract functions, classes, etc.]
-    D -.- D1[OrtEmbedding<br/>all-MiniLM-L6-v2]
+    D -.- D1[OrtEmbedding<br/>Qwen3-Embedding-0.6B]
     E -.- E1[DuckdbMetadataRepository<br/>+ DuckdbVectorRepository<br/>Metadata + Vectors]
 ```
 

--- a/docs/features/embedding-backends.md
+++ b/docs/features/embedding-backends.md
@@ -28,11 +28,11 @@ codesearch index . --embedding-model sentence-transformers/all-mpnet-base-v2 --e
 
 | Model | Dimensions | Download size |
 |-------|------------|---------------|
-| `sentence-transformers/all-MiniLM-L6-v2` | 384 | ~90 MB |
+| `Qwen/Qwen3-Embedding-0.6B` | 1024 | ~600 MB |
 
 ### Reranking (ONNX)
 
-When the ONNX backend is active, reranking uses `BAAI/bge-reranker-base` as a cross-encoder, downloaded automatically. Disable it with `--no-rerank`.
+When the ONNX backend is active, reranking uses `Qwen/Qwen3-Reranker-0.6B` as a cross-encoder, downloaded automatically. Disable it with `--no-rerank`.
 
 ---
 
@@ -61,7 +61,7 @@ All API-target traffic shares the same environment variables used by query expan
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `ANTHROPIC_BASE_URL` | `http://localhost:1234` | Base URL for embeddings (`/v1/embeddings`) and reranking (`/v1/messages`) |
-| `ANTHROPIC_MODEL` | `mistralai/ministral-3-3b` | Chat model used for reranking |
+| `ANTHROPIC_MODEL` | `qwen/qwen3.5-4b` | Chat model used for reranking |
 | `ANTHROPIC_API_KEY` | `""` | API key — not required for local servers |
 
 > LM Studio exposes both `/v1/embeddings` (OpenAI-compatible) and `/v1/messages` (Anthropic-compatible) on the same port, so one `ANTHROPIC_BASE_URL` covers everything.
@@ -92,8 +92,8 @@ The embedding configuration for a namespace is written to the `namespace_config`
 namespace_config
 ├── namespace        (e.g. "search")
 ├── embedding_target (e.g. "onnx" or "api")
-├── embedding_model  (e.g. "sentence-transformers/all-MiniLM-L6-v2")
-└── dimensions       (e.g. 384)
+├── embedding_model  (e.g. "Qwen/Qwen3-Embedding-0.6B")
+└── dimensions       (e.g. 1024)
 ```
 
 The `embeddings` table schema is created with `FLOAT[{dimensions}]`, so the column type is fixed at namespace creation time.
@@ -108,8 +108,8 @@ The `embeddings` table schema is created with `FLOAT[{dimensions}]`, so the colu
 Both errors include an actionable message:
 
 ```
-Namespace 'search' was indexed with 384-dimensional embeddings
-(model 'sentence-transformers/all-MiniLM-L6-v2', target 'onnx')
+Namespace 'search' was indexed with 1024-dimensional embeddings
+(model 'Qwen/Qwen3-Embedding-0.6B', target 'onnx')
 but you are now using 768-dimensional embeddings
 (model 'nomic-embed-text', target 'api').
 Re-index with `codesearch index --force` using the original model,
@@ -148,7 +148,7 @@ All embedding flags are global — they apply to `index`, `search`, `mcp`, and a
 ```
 --embedding-target <onnx|api>      Embedding backend (default: onnx)
 --embedding-model <name>           HuggingFace ID (onnx) or API model name
---embedding-dimensions <n>         Output dimensions (default: 384)
+--embedding-dimensions <n>         Output dimensions (default: 1024)
 ```
 
 These flags should be passed consistently across `index` and `search` — the namespace config validator will catch mismatches, but it's easiest to set them in a shell alias or wrapper script.
@@ -179,4 +179,4 @@ alias cs-lm='codesearch \
 | Indexing speed | Fast (local inference) | Depends on server |
 | Memory usage | ~200 MB (model in RAM) | Minimal |
 | Model flexibility | Any HuggingFace ONNX model | Any model LM Studio supports |
-| Reranking | Cross-encoder (BAAI/bge-reranker-base) | LLM-based (same chat model) |
+| Reranking | Cross-encoder (Qwen/Qwen3-Reranker-0.6B) | LLM-based (same chat model) |

--- a/docs/features/embedding-backends.md
+++ b/docs/features/embedding-backends.md
@@ -32,7 +32,7 @@ codesearch index . --embedding-model sentence-transformers/all-mpnet-base-v2 --e
 
 ### Reranking (ONNX)
 
-When the ONNX backend is active, reranking uses `Qwen/Qwen3-Reranker-0.6B` as a cross-encoder, downloaded automatically. Disable it with `--no-rerank`.
+When the ONNX backend is active, reranking uses `Qwen/Qwen3-Reranker-0.6B` — a causal (decoder-style) reranker scored from its yes/no token logits — downloaded automatically. BERT-style cross-encoders such as `BAAI/bge-reranker-base` are also supported and auto-detected. Disable reranking with `--no-rerank`.
 
 ---
 
@@ -179,4 +179,4 @@ alias cs-lm='codesearch \
 | Indexing speed | Fast (local inference) | Depends on server |
 | Memory usage | ~200 MB (model in RAM) | Minimal |
 | Model flexibility | Any HuggingFace ONNX model | Any model LM Studio supports |
-| Reranking | Cross-encoder (Qwen/Qwen3-Reranker-0.6B) | LLM-based (same chat model) |
+| Reranking | Causal reranker (Qwen/Qwen3-Reranker-0.6B) | LLM-based (same chat model) |

--- a/docs/features/getting-started.md
+++ b/docs/features/getting-started.md
@@ -171,7 +171,7 @@ Codesearch defaults to **hybrid search** — a semantic (vector) leg and a keywo
 1. Your query is converted to a 1024-dimensional embedding
 2. The DuckDB VSS extension finds semantically similar code using HNSW indexes
 3. In parallel, a keyword leg matches content and symbol names; the two ranked lists are fused with RRF (pass `--no-text-search` for semantic-only)
-4. A cross-encoder reranker (Qwen3-Reranker-0.6B) rescores candidates for higher relevance (enabled by default, disable with `--no-rerank`)
+4. A causal reranker (`Qwen/Qwen3-Reranker-0.6B`) rescores candidates for higher relevance (enabled by default, disable with `--no-rerank`)
 5. Results are ranked by fused RRF score (hybrid), cosine similarity (semantic-only), or reranking score
 6. Filters can be applied by language, node type, repository, or minimum score
 

--- a/docs/features/getting-started.md
+++ b/docs/features/getting-started.md
@@ -168,10 +168,10 @@ codesearch -v search "my query"
 Codesearch defaults to **hybrid search** — a semantic (vector) leg and a keyword
 (BM25-style) leg, fused via Reciprocal Rank Fusion (RRF):
 
-1. Your query is converted to a 384-dimensional embedding
+1. Your query is converted to a 1024-dimensional embedding
 2. The DuckDB VSS extension finds semantically similar code using HNSW indexes
 3. In parallel, a keyword leg matches content and symbol names; the two ranked lists are fused with RRF (pass `--no-text-search` for semantic-only)
-4. A cross-encoder reranker (bge-reranker-base) rescores candidates for higher relevance (enabled by default, disable with `--no-rerank`)
+4. A cross-encoder reranker (Qwen3-Reranker-0.6B) rescores candidates for higher relevance (enabled by default, disable with `--no-rerank`)
 5. Results are ranked by fused RRF score (hybrid), cosine similarity (semantic-only), or reranking score
 6. Filters can be applied by language, node type, repository, or minimum score
 

--- a/docs/features/indexing.md
+++ b/docs/features/indexing.md
@@ -244,7 +244,7 @@ Return Results
 
 | Backend | Reranking method | Model |
 |---------|-----------------|-------|
-| ONNX | Cross-encoder (ONNX) | `Qwen/Qwen3-Reranker-0.6B` (~600 MB, downloaded automatically) |
+| ONNX | Causal reranker (ONNX); auto-detects BERT-style cross-encoders too | `Qwen/Qwen3-Reranker-0.6B` (~600 MB, downloaded automatically) |
 | API | LLM-based (single prompt, JSON scores) | Chat model at `ANTHROPIC_BASE_URL` (`ANTHROPIC_MODEL`) |
 
 ### Usage

--- a/docs/features/indexing.md
+++ b/docs/features/indexing.md
@@ -73,7 +73,7 @@ Two backends are available — see [Embedding Backends](./embedding-backends.md)
 
 | Backend | Flag | Default model | Dimensions |
 |---------|------|---------------|------------|
-| ONNX (local, default) | `--embedding-target=onnx` | `sentence-transformers/all-MiniLM-L6-v2` | 384 |
+| ONNX (local, default) | `--embedding-target=onnx` | `Qwen/Qwen3-Embedding-0.6B` | 1024 |
 | API (OpenAI-compatible) | `--embedding-target=api` | Configured via `--embedding-model` | Configured via `--embedding-dimensions` |
 
 The model and dimension count are stored in the `namespace_config` DuckDB table on first index and validated on every subsequent open — mismatches are hard errors.
@@ -96,7 +96,7 @@ Data is stored using configurable backends:
 > The `repositories` and `namespace_config` tables are **global** (one per database file, not namespace-scoped), so each row records which namespace it belongs to. This is what makes [automatic namespace resolution](#automatic-namespace-resolution) a single cheap lookup.
 
 **Vectors** (via `DuckdbVectorRepository` with VSS):
-- Stores `FLOAT[{dimensions}]` embedding vectors directly in DuckDB — the column width is fixed at namespace creation time based on `--embedding-dimensions` (default 384)
+- Stores `FLOAT[{dimensions}]` embedding vectors directly in DuckDB — the column width is fixed at namespace creation time based on `--embedding-dimensions` (default 1024)
 - **VSS (Vector Similarity Search) acceleration**:
   - Uses HNSW (Hierarchical Navigable Small World) index
   - Cosine distance metric for similarity calculations
@@ -244,7 +244,7 @@ Return Results
 
 | Backend | Reranking method | Model |
 |---------|-----------------|-------|
-| ONNX | Cross-encoder (ONNX) | `BAAI/bge-reranker-base` (~220 MB, downloaded automatically) |
+| ONNX | Cross-encoder (ONNX) | `Qwen/Qwen3-Reranker-0.6B` (~600 MB, downloaded automatically) |
 | API | LLM-based (single prompt, JSON scores) | Chat model at `ANTHROPIC_BASE_URL` (`ANTHROPIC_MODEL`) |
 
 ### Usage

--- a/docs/features/search.md
+++ b/docs/features/search.md
@@ -82,7 +82,7 @@ codesearch search "validation" --no-rerank
 - Fetches candidates from hybrid or vector search using an inverse-log formula: `num + ⌈num / ln(num)⌉` (defaults to 20 base candidates when `num ≤ 10`)
 - For **semantic-only** results, filters out candidates with vector similarity score below 0.1 (too irrelevant to benefit from reranking)
 - For **hybrid** results, the 0.1 threshold is bypassed — RRF scores are intentionally small (~0.016–0.033) and all fused results are passed to the reranker
-- Rescores remaining candidates using a cross-encoder model (bge-reranker-base)
+- Rescores remaining candidates using a cross-encoder model (Qwen3-Reranker-0.6B)
 - Returns top `num` results by relevance score
 
 **Trade-offs:**

--- a/docs/features/search.md
+++ b/docs/features/search.md
@@ -82,7 +82,7 @@ codesearch search "validation" --no-rerank
 - Fetches candidates from hybrid or vector search using an inverse-log formula: `num + ⌈num / ln(num)⌉` (defaults to 20 base candidates when `num ≤ 10`)
 - For **semantic-only** results, filters out candidates with vector similarity score below 0.1 (too irrelevant to benefit from reranking)
 - For **hybrid** results, the 0.1 threshold is bypassed — RRF scores are intentionally small (~0.016–0.033) and all fused results are passed to the reranker
-- Rescores remaining candidates using a cross-encoder model (Qwen3-Reranker-0.6B)
+- Rescores remaining candidates using a causal reranker (`Qwen/Qwen3-Reranker-0.6B`)
 - Returns top `num` results by relevance score
 
 **Trade-offs:**

--- a/src/connector/adapter/anthropic_client.rs
+++ b/src/connector/adapter/anthropic_client.rs
@@ -14,7 +14,7 @@ pub const DEFAULT_BASE_URL: &str = "http://localhost:1234";
 const MESSAGES_PATH: &str = "/v1/messages";
 const ANTHROPIC_API_VERSION: &str = "2023-06-01";
 /// Default model matches the LM Studio local-first default.
-const DEFAULT_MODEL: &str = "mistralai/ministral-3-3b";
+const DEFAULT_MODEL: &str = "qwen/qwen3.5-4b";
 /// Budget is set high so that thinking-mode models (e.g. Qwen with extended
 /// thinking) can spend tokens on their `<think>` pass without exhausting the
 /// budget before the actual XML response is written.
@@ -106,7 +106,7 @@ enum StreamDelta {
 /// ```text
 /// ANTHROPIC_BASE_URL=https://api.anthropic.com
 /// ANTHROPIC_API_KEY=sk-ant-...
-/// ANTHROPIC_MODEL=claude-haiku-4-5
+/// ANTHROPIC_MODEL=qwen/qwen3.5-4b
 /// ```
 ///
 /// The first call to `complete` probes the base URL with a 2-second timeout.
@@ -159,7 +159,7 @@ impl AnthropicClient {
     /// | Variable             | Default                   | Purpose                   |
     /// |----------------------|---------------------------|---------------------------|
     /// | `ANTHROPIC_BASE_URL` | `http://localhost:1234`   | LM Studio / any server    |
-    /// | `ANTHROPIC_MODEL`    | `mistralai/ministral-3-3b` | Model in LM Studio       |
+    /// | `ANTHROPIC_MODEL`    | `qwen/qwen3.5-4b`         | Model in LM Studio       |
     /// | `ANTHROPIC_API_KEY`  | `""` (empty)              | Not required for local    |
     pub fn from_env() -> Self {
         let base =

--- a/src/connector/adapter/anthropic_reranking.rs
+++ b/src/connector/adapter/anthropic_reranking.rs
@@ -39,7 +39,7 @@ Example output: [0.97, 0.02]";
 /// | Variable             | Default                    |
 /// |----------------------|----------------------------|
 /// | `ANTHROPIC_BASE_URL` | `http://localhost:1234`    |
-/// | `ANTHROPIC_MODEL`    | `mistralai/ministral-3-3b` |
+/// | `ANTHROPIC_MODEL`    | `qwen/qwen3.5-4b`          |
 /// | `ANTHROPIC_API_KEY`  | `""` (not required locally)|
 pub struct AnthropicReranking {
     client: Arc<dyn ChatClient>,

--- a/src/connector/adapter/lm_studio_reranking.rs
+++ b/src/connector/adapter/lm_studio_reranking.rs
@@ -39,7 +39,7 @@ Example output: [0.97, 0.02]";
 /// | Variable             | Default                    |
 /// |----------------------|----------------------------|
 /// | `ANTHROPIC_BASE_URL` | `http://localhost:1234`    |
-/// | `ANTHROPIC_MODEL`    | `mistralai/ministral-3-3b` |
+/// | `ANTHROPIC_MODEL`    | `qwen/qwen3.5-4b`          |
 /// | `ANTHROPIC_API_KEY`  | `""` (not required locally)|
 pub struct LmStudioReranking {
     client: Arc<dyn ChatClient>,

--- a/src/connector/adapter/openai_chat_client.rs
+++ b/src/connector/adapter/openai_chat_client.rs
@@ -66,7 +66,7 @@ struct StreamDelta {
 /// | Variable          | Default                    |
 /// |-------------------|----------------------------|
 /// | `OPENAI_BASE_URL` | `http://localhost:1234`    |
-/// | `OPENAI_MODEL`    | `openai-chat`              |
+/// | `OPENAI_MODEL`    | `qwen/qwen3.5-4b`          |
 /// | `OPENAI_API_KEY`  | `""` (not required locally)|
 pub struct OpenAiChatClient {
     client: reqwest::Client,
@@ -79,7 +79,7 @@ impl OpenAiChatClient {
         let base =
             std::env::var("OPENAI_BASE_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
         let url = format!("{}{}", base.trim_end_matches('/'), CHAT_PATH);
-        let model = std::env::var("OPENAI_MODEL").unwrap_or_else(|_| "openai-chat".to_string());
+        let model = std::env::var("OPENAI_MODEL").unwrap_or_else(|_| "qwen/qwen3.5-4b".to_string());
 
         debug!("OpenAiChatClient: endpoint={}, model={}", url, model);
 

--- a/src/connector/adapter/openai_reranking.rs
+++ b/src/connector/adapter/openai_reranking.rs
@@ -37,7 +37,7 @@ Example output: [0.97, 0.02]";
 /// | Variable          | Default                    |
 /// |-------------------|----------------------------|
 /// | `OPENAI_BASE_URL` | `http://localhost:1234`    |
-/// | `OPENAI_MODEL`    | `openai-chat`              |
+/// | `OPENAI_MODEL`    | `qwen/qwen3.5-4b`          |
 /// | `OPENAI_API_KEY`  | `""` (not required locally)|
 pub struct OpenAiReranking {
     client: Arc<dyn ChatClient>,
@@ -47,7 +47,7 @@ pub struct OpenAiReranking {
 impl OpenAiReranking {
     pub fn new(client: Arc<dyn ChatClient>) -> Self {
         let model_name =
-            std::env::var("OPENAI_MODEL").unwrap_or_else(|_| "openai-chat".to_string());
+            std::env::var("OPENAI_MODEL").unwrap_or_else(|_| "qwen/qwen3.5-4b".to_string());
         Self { client, model_name }
     }
 

--- a/src/connector/adapter/ort_embedding.rs
+++ b/src/connector/adapter/ort_embedding.rs
@@ -12,16 +12,17 @@ use tracing::debug;
 use crate::application::EmbeddingService;
 use crate::domain::{CodeChunk, DomainError, Embedding, EmbeddingConfig};
 
-const DEFAULT_MODEL_ID: &str = "sentence-transformers/all-MiniLM-L6-v2";
-const DEFAULT_DIMENSIONS: usize = 384;
+const DEFAULT_MODEL_ID: &str = "Qwen/Qwen3-Embedding-0.6B";
+const DEFAULT_DIMENSIONS: usize = 1024;
 const DEFAULT_MAX_SEQ_LENGTH: usize = 512;
 /// Number of chunks processed per ONNX inference call.
 ///
 /// Larger batches amortise per-call overhead and improve CPU utilisation
-/// via wider SIMD/matrix operations.  128 is a good default for the small
-/// all-MiniLM-L6-v2 model (22M params, 384-dim) without risking OOM even
-/// on machines with modest RAM.
-const BATCH_SIZE: usize = 128;
+/// via wider SIMD/matrix operations.  Qwen3-Embedding-0.6B (600M params,
+/// 1024-dim) is far heavier than the previous all-MiniLM-L6-v2 default, so
+/// 32 keeps peak memory bounded on machines with modest RAM while still
+/// amortising per-call overhead.
+const BATCH_SIZE: usize = 32;
 
 pub struct OrtEmbedding {
     session: Arc<Mutex<Session>>,

--- a/src/connector/adapter/ort_embedding.rs
+++ b/src/connector/adapter/ort_embedding.rs
@@ -12,7 +12,6 @@ use tracing::debug;
 use crate::application::EmbeddingService;
 use crate::domain::{CodeChunk, DomainError, Embedding, EmbeddingConfig};
 
-const DEFAULT_MODEL_ID: &str = "Qwen/Qwen3-Embedding-0.6B";
 const DEFAULT_DIMENSIONS: usize = 1024;
 const DEFAULT_MAX_SEQ_LENGTH: usize = 512;
 /// Number of chunks processed per ONNX inference call.
@@ -57,8 +56,13 @@ pub struct OrtEmbedding {
 }
 
 impl OrtEmbedding {
+    /// Default HuggingFace model id used when no `--embedding-model` is given.
+    /// Exposed so the DI container records the same model in namespace metadata
+    /// that indexing actually uses, avoiding drift between the two.
+    pub(crate) const DEFAULT_MODEL_ID: &'static str = "Qwen/Qwen3-Embedding-0.6B";
+
     pub fn new(model_id: Option<&str>) -> Result<Self, DomainError> {
-        let model_id = model_id.unwrap_or(DEFAULT_MODEL_ID);
+        let model_id = model_id.unwrap_or(Self::DEFAULT_MODEL_ID);
         debug!(
             "Initializing ORT embedding service with model: {}",
             model_id

--- a/src/connector/adapter/ort_embedding.rs
+++ b/src/connector/adapter/ort_embedding.rs
@@ -24,6 +24,26 @@ const DEFAULT_MAX_SEQ_LENGTH: usize = 512;
 /// amortising per-call overhead.
 const BATCH_SIZE: usize = 32;
 
+/// Instruction prepended to *queries* (not documents) for instruction-tuned
+/// embedding models such as Qwen3-Embedding.  The model was trained to embed
+/// queries in the form `Instruct: {task}\nQuery: {text}`; documents are embedded
+/// verbatim.  Using a code-retrieval-flavoured task description nudges the model
+/// toward the right embedding subspace for this tool.
+const QUERY_INSTRUCTION: &str =
+    "Given a code search query, retrieve relevant code that matches the query";
+
+/// How the per-token hidden states emitted by a `[batch, seq, hidden]` model are
+/// reduced to a single vector per sequence.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Pooling {
+    /// Attention-masked mean over all tokens — the convention for BERT-style
+    /// sentence-transformers models (e.g. all-MiniLM-L6-v2).
+    Mean,
+    /// Hidden state of the last non-padded token — the convention for
+    /// causal/decoder embedding models (e.g. Qwen3-Embedding).
+    LastToken,
+}
+
 pub struct OrtEmbedding {
     session: Arc<Mutex<Session>>,
     tokenizer: Arc<Tokenizer>,
@@ -32,6 +52,8 @@ pub struct OrtEmbedding {
     /// input (e.g. BERT-style models).  All-zero segment IDs are used because
     /// embedding models always encode a single sequence.
     needs_token_type_ids: bool,
+    /// Pooling strategy applied to `[batch, seq, hidden]` outputs.
+    pooling: Pooling,
 }
 
 impl OrtEmbedding {
@@ -83,6 +105,17 @@ impl OrtEmbedding {
             .iter()
             .any(|i| i.name() == "token_type_ids");
 
+        // Pooling is inferred from the model architecture: BERT-style encoders
+        // declare a `token_type_ids` (segment) input and are mean-pooled, while
+        // causal/decoder embedding models (Qwen3-Embedding) have no segment
+        // input and are pooled on their last token.
+        let pooling = if needs_token_type_ids {
+            Pooling::Mean
+        } else {
+            Pooling::LastToken
+        };
+        debug!("Embedding pooling strategy: {:?}", pooling);
+
         let config = EmbeddingConfig::new(
             model_name.to_string(),
             DEFAULT_DIMENSIONS,
@@ -94,6 +127,7 @@ impl OrtEmbedding {
             tokenizer: Arc::new(tokenizer),
             config,
             needs_token_type_ids,
+            pooling,
         })
     }
 }
@@ -108,6 +142,7 @@ fn embed_texts_impl(
     tokenizer: &Tokenizer,
     max_seq_length: usize,
     needs_token_type_ids: bool,
+    pooling: Pooling,
     texts: &[String],
 ) -> Result<Vec<Vec<f32>>, DomainError> {
     if texts.is_empty() {
@@ -145,9 +180,8 @@ fn embed_texts_impl(
     }
 
     let shape = [batch_size, max_len];
-    let input_ids_tensor = Tensor::from_array((shape, input_ids)).map_err(|e| {
-        DomainError::internal(format!("Failed to create input_ids tensor: {}", e))
-    })?;
+    let input_ids_tensor = Tensor::from_array((shape, input_ids))
+        .map_err(|e| DomainError::internal(format!("Failed to create input_ids tensor: {}", e)))?;
     let attention_mask_tensor = Tensor::from_array((shape, attention_mask)).map_err(|e| {
         DomainError::internal(format!("Failed to create attention_mask tensor: {}", e))
     })?;
@@ -158,13 +192,9 @@ fn embed_texts_impl(
 
     let outputs = if needs_token_type_ids {
         let token_type_ids = vec![0i64; batch_size * max_len];
-        let token_type_ids_tensor =
-            Tensor::from_array((shape, token_type_ids)).map_err(|e| {
-                DomainError::internal(format!(
-                    "Failed to create token_type_ids tensor: {}",
-                    e
-                ))
-            })?;
+        let token_type_ids_tensor = Tensor::from_array((shape, token_type_ids)).map_err(|e| {
+            DomainError::internal(format!("Failed to create token_type_ids tensor: {}", e))
+        })?;
         session_guard.run(ort::inputs![
             "input_ids" => input_ids_tensor,
             "attention_mask" => attention_mask_tensor,
@@ -183,9 +213,9 @@ fn embed_texts_impl(
         .next()
         .ok_or_else(|| DomainError::internal("No output tensor found"))?;
 
-    let (shape, data) = output_value.try_extract_tensor::<f32>().map_err(|e| {
-        DomainError::internal(format!("Failed to extract output tensor: {}", e))
-    })?;
+    let (shape, data) = output_value
+        .try_extract_tensor::<f32>()
+        .map_err(|e| DomainError::internal(format!("Failed to extract output tensor: {}", e)))?;
 
     let shape: Vec<usize> = shape.iter().map(|&x| x as usize).collect();
     debug!("Output tensor shape: {:?}", shape);
@@ -196,26 +226,39 @@ fn embed_texts_impl(
 
         (0..batch_size)
             .map(|i| {
-                let mut embedding = vec![0.0f32; hidden_size];
-                let mut count = 0.0f32;
-
                 let mask = encodings[i].get_attention_mask();
-                for j in 0..seq_len.min(max_len) {
-                    let mask_val = if j < mask.len() { mask[j] as f32 } else { 0.0 };
-                    if mask_val > 0.0 {
-                        for (k, emb_k) in embedding.iter_mut().enumerate().take(hidden_size) {
-                            let idx = i * seq_len * hidden_size + j * hidden_size + k;
-                            *emb_k += data[idx] * mask_val;
+                let mut embedding = match pooling {
+                    Pooling::Mean => {
+                        let mut acc = vec![0.0f32; hidden_size];
+                        let mut count = 0.0f32;
+                        for j in 0..seq_len.min(max_len) {
+                            let mask_val = if j < mask.len() { mask[j] as f32 } else { 0.0 };
+                            if mask_val > 0.0 {
+                                for (k, emb_k) in acc.iter_mut().enumerate().take(hidden_size) {
+                                    let idx = i * seq_len * hidden_size + j * hidden_size + k;
+                                    *emb_k += data[idx] * mask_val;
+                                }
+                                count += mask_val;
+                            }
                         }
-                        count += mask_val;
+                        if count > 0.0 {
+                            for v in &mut acc {
+                                *v /= count;
+                            }
+                        }
+                        acc
                     }
-                }
-
-                if count > 0.0 {
-                    for v in &mut embedding {
-                        *v /= count;
+                    Pooling::LastToken => {
+                        // Index of the last attended token.  Inputs are
+                        // right-padded, so this is `(number of real tokens) - 1`,
+                        // clamped to the model's sequence length.
+                        let real_len = mask.iter().take(max_len).filter(|&&m| m > 0).count();
+                        let last = real_len.saturating_sub(1).min(seq_len.saturating_sub(1));
+                        (0..hidden_size)
+                            .map(|k| data[i * seq_len * hidden_size + last * hidden_size + k])
+                            .collect()
                     }
-                }
+                };
 
                 let norm: f32 = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
                 if norm > 0.0 {
@@ -268,11 +311,12 @@ impl EmbeddingService for OrtEmbedding {
         let tokenizer = Arc::clone(&self.tokenizer);
         let max_seq = self.config.max_sequence_length();
         let needs_tti = self.needs_token_type_ids;
+        let pooling = self.pooling;
         let model_name = self.config.model_name().to_string();
         let chunk_id = chunk.id().to_string();
 
         let vectors = tokio::task::spawn_blocking(move || {
-            embed_texts_impl(&session, &tokenizer, max_seq, needs_tti, &[text])
+            embed_texts_impl(&session, &tokenizer, max_seq, needs_tti, pooling, &[text])
         })
         .await
         .map_err(|e| DomainError::internal(format!("Embedding task panicked: {e}")))??;
@@ -308,9 +352,10 @@ impl EmbeddingService for OrtEmbedding {
             let tokenizer = Arc::clone(&self.tokenizer);
             let max_seq = self.config.max_sequence_length();
             let needs_tti = self.needs_token_type_ids;
+            let pooling = self.pooling;
 
             let vectors = tokio::task::spawn_blocking(move || {
-                embed_texts_impl(&session, &tokenizer, max_seq, needs_tti, &texts)
+                embed_texts_impl(&session, &tokenizer, max_seq, needs_tti, pooling, &texts)
             })
             .await
             .map_err(|e| DomainError::internal(format!("Embedding task panicked: {e}")))??;
@@ -337,14 +382,21 @@ impl EmbeddingService for OrtEmbedding {
     }
 
     async fn embed_query(&self, query: &str) -> Result<Vec<f32>, DomainError> {
-        let text = query.to_string();
+        // Instruction-tuned (last-token) models expect queries wrapped in an
+        // `Instruct: ...\nQuery: ...` template; documents are left bare so the
+        // two sides of the retrieval pair stay in the trained format.
+        let text = match self.pooling {
+            Pooling::LastToken => format!("Instruct: {QUERY_INSTRUCTION}\nQuery: {query}"),
+            Pooling::Mean => query.to_string(),
+        };
         let session = Arc::clone(&self.session);
         let tokenizer = Arc::clone(&self.tokenizer);
         let max_seq = self.config.max_sequence_length();
         let needs_tti = self.needs_token_type_ids;
+        let pooling = self.pooling;
 
         let vectors = tokio::task::spawn_blocking(move || {
-            embed_texts_impl(&session, &tokenizer, max_seq, needs_tti, &[text])
+            embed_texts_impl(&session, &tokenizer, max_seq, needs_tti, pooling, &[text])
         })
         .await
         .map_err(|e| DomainError::internal(format!("Embedding task panicked: {e}")))??;

--- a/src/connector/adapter/ort_reranking.rs
+++ b/src/connector/adapter/ort_reranking.rs
@@ -291,11 +291,15 @@ impl OrtReranking {
         };
         let (yes_id, no_id) = (yes_id as usize, no_id as usize);
 
-        let prompts: Vec<String> = documents
+        // Build the prompt body (everything except the trailing assistant
+        // suffix) separately so the suffix — which holds the position where the
+        // model emits its yes/no answer — always survives truncation of a long
+        // document rather than being dropped off the end.
+        let bodies: Vec<String> = documents
             .iter()
             .map(|doc| {
                 format!(
-                    "{QWEN_PREFIX}<Instruct>: {QWEN_INSTRUCTION}\n<Query>: {query}\n<Document>: {doc}{QWEN_SUFFIX}"
+                    "{QWEN_PREFIX}<Instruct>: {QWEN_INSTRUCTION}\n<Query>: {query}\n<Document>: {doc}"
                 )
             })
             .collect();
@@ -303,38 +307,52 @@ impl OrtReranking {
         // The chat-template markers (`<|im_start|>`, `<think>`, …) are added
         // tokens the tokenizer maps directly, so no extra special tokens are
         // injected here.
+        let suffix_ids: Vec<i64> = self
+            .tokenizer
+            .encode(QWEN_SUFFIX, false)
+            .map_err(|e| DomainError::internal(format!("Tokenization failed: {}", e)))?
+            .get_ids()
+            .iter()
+            .map(|&x| x as i64)
+            .collect();
+        let suffix_len = suffix_ids.len();
+        // Tokens left for the body once room for the suffix is reserved.
+        let body_budget = self.max_sequence_length.saturating_sub(suffix_len);
+
         let encodings = self
             .tokenizer
-            .encode_batch(prompts.iter().map(|s| s.as_str()).collect(), false)
+            .encode_batch(bodies.iter().map(|s| s.as_str()).collect(), false)
             .map_err(|e| DomainError::internal(format!("Tokenization failed: {}", e)))?;
 
-        let max_len = encodings
+        let max_body = encodings
             .iter()
-            .map(|e| e.get_ids().len())
+            .map(|e| e.get_ids().len().min(body_budget))
             .max()
-            .unwrap_or(0)
-            .min(self.max_sequence_length);
+            .unwrap_or(0);
+        let max_len = max_body + suffix_len;
 
         let mut input_ids: Vec<i64> = Vec::with_capacity(batch_size * max_len);
         let mut attention_mask: Vec<i64> = Vec::with_capacity(batch_size * max_len);
-        // Index of the last real (non-padded) token per sequence; this is where
-        // a causal LM emits its answer logits.
+        // Index of the last real (non-padded) token per sequence: the final
+        // suffix token, where the causal LM emits its yes/no answer logits.
         let mut last_idx: Vec<usize> = Vec::with_capacity(batch_size);
 
         for encoding in &encodings {
             let ids = encoding.get_ids();
-            let mask = encoding.get_attention_mask();
+            let body_len = ids.len().min(body_budget);
 
-            let len = ids.len().min(max_len);
+            // Truncated body followed by the full (always-present) suffix.
+            input_ids.extend(ids[..body_len].iter().map(|&x| x as i64));
+            input_ids.extend(suffix_ids.iter().copied());
 
-            input_ids.extend(ids[..len].iter().map(|&x| x as i64));
-            attention_mask.extend(mask[..len].iter().map(|&x| x as i64));
+            let real_len = body_len + suffix_len;
+            attention_mask.extend(std::iter::repeat_n(1i64, real_len));
 
-            let padding = max_len - len;
+            let padding = max_len - real_len;
             input_ids.extend(std::iter::repeat_n(0i64, padding));
             attention_mask.extend(std::iter::repeat_n(0i64, padding));
 
-            last_idx.push(len.saturating_sub(1));
+            last_idx.push(real_len.saturating_sub(1));
         }
 
         let shape = [batch_size, max_len];

--- a/src/connector/adapter/ort_reranking.rs
+++ b/src/connector/adapter/ort_reranking.rs
@@ -13,7 +13,7 @@ use tracing::{debug, info};
 use crate::application::RerankingService;
 use crate::domain::{DomainError, SearchResult};
 
-const DEFAULT_MODEL_ID: &str = "BAAI/bge-reranker-base";
+const DEFAULT_MODEL_ID: &str = "Qwen/Qwen3-Reranker-0.6B";
 const DEFAULT_MAX_SEQ_LENGTH: usize = 512;
 const BATCH_SIZE: usize = 32;
 

--- a/src/connector/adapter/ort_reranking.rs
+++ b/src/connector/adapter/ort_reranking.rs
@@ -8,7 +8,7 @@ use ort::{
     value::Tensor,
 };
 use tokenizers::Tokenizer;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::application::RerankingService;
 use crate::domain::{DomainError, SearchResult};
@@ -17,15 +17,41 @@ const DEFAULT_MODEL_ID: &str = "Qwen/Qwen3-Reranker-0.6B";
 const DEFAULT_MAX_SEQ_LENGTH: usize = 512;
 const BATCH_SIZE: usize = 32;
 
+/// Task description embedded in the Qwen reranker prompt's `<Instruct>` slot.
+const QWEN_INSTRUCTION: &str =
+    "Given a code search query, retrieve relevant code that matches the query";
+/// Chat-template prefix that precedes the query/document content for the Qwen3
+/// reranker.  The model is a causal LM trained to answer "yes"/"no".
+const QWEN_PREFIX: &str = "<|im_start|>system\nJudge whether the Document meets the requirements based on the Query and the Instruct provided. Note that the answer can only be \"yes\" or \"no\".<|im_end|>\n<|im_start|>user\n";
+/// Chat-template suffix that closes the prompt and primes the assistant turn.
+const QWEN_SUFFIX: &str = "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n";
+
+/// Which scoring scheme the loaded ONNX reranker uses.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum RerankerKind {
+    /// BERT-style cross-encoder emitting a single relevance logit per pair
+    /// (e.g. BAAI/bge-reranker-base).  Scored with a sigmoid.
+    CrossEncoder,
+    /// Causal/decoder reranker (e.g. Qwen3-Reranker) that answers "yes"/"no";
+    /// scored from the softmax of the yes/no token logits at the last position.
+    Causal,
+}
+
 pub struct OrtReranking {
     session: Arc<Mutex<Session>>,
     tokenizer: Arc<Tokenizer>,
     model_name: String,
     max_sequence_length: usize,
     /// True when the loaded ONNX model declares `token_type_ids` as a required
-    /// input.  For reranker models the segment IDs from the tokenizer are used
-    /// (0 = query tokens, 1 = document tokens).
+    /// input.  For cross-encoder models the segment IDs from the tokenizer are
+    /// used (0 = query tokens, 1 = document tokens).
     needs_token_type_ids: bool,
+    /// Scoring scheme inferred from the model architecture at load time.
+    kind: RerankerKind,
+    /// Vocabulary id of the "yes" token (Causal kind only).
+    token_true_id: Option<u32>,
+    /// Vocabulary id of the "no" token (Causal kind only).
+    token_false_id: Option<u32>,
 }
 
 impl OrtReranking {
@@ -77,12 +103,40 @@ impl OrtReranking {
             .iter()
             .any(|i| i.name() == "token_type_ids");
 
+        // A BERT-style cross-encoder declares a `token_type_ids` (segment) input;
+        // a causal/decoder reranker (Qwen3-Reranker) does not.  The latter is
+        // scored from yes/no token logits, so resolve those vocabulary ids up
+        // front.
+        let kind = if needs_token_type_ids {
+            RerankerKind::CrossEncoder
+        } else {
+            RerankerKind::Causal
+        };
+        let (token_true_id, token_false_id) = if kind == RerankerKind::Causal {
+            let yes = tokenizer.token_to_id("yes");
+            let no = tokenizer.token_to_id("no");
+            if yes.is_none() || no.is_none() {
+                warn!(
+                    "OrtReranking: causal reranker '{}' is missing a 'yes'/'no' token \
+                     in its vocabulary; reranking will preserve retrieval order",
+                    model_name
+                );
+            }
+            (yes, no)
+        } else {
+            (None, None)
+        };
+        debug!("Reranker kind: {:?}", kind);
+
         Ok(Self {
             session: Arc::new(Mutex::new(session)),
             tokenizer: Arc::new(tokenizer),
             model_name: model_name.to_string(),
             max_sequence_length: DEFAULT_MAX_SEQ_LENGTH,
             needs_token_type_ids,
+            kind,
+            token_true_id,
+            token_false_id,
         })
     }
 
@@ -90,7 +144,19 @@ impl OrtReranking {
         if documents.is_empty() {
             return Ok(vec![]);
         }
+        match self.kind {
+            RerankerKind::CrossEncoder => self.rerank_batch_cross_encoder(query, documents),
+            RerankerKind::Causal => self.rerank_batch_causal(query, documents),
+        }
+    }
 
+    /// BERT-style cross-encoder scoring: tokenize query/document pairs and apply
+    /// a sigmoid to the single relevance logit.
+    fn rerank_batch_cross_encoder(
+        &self,
+        query: &str,
+        documents: &[&str],
+    ) -> Result<Vec<f32>, DomainError> {
         let batch_size = documents.len();
 
         // Tokenize query-document pairs
@@ -202,6 +268,136 @@ impl OrtReranking {
                 shape
             )));
         };
+
+        Ok(scores)
+    }
+
+    /// Causal (Qwen3-Reranker) scoring: wrap each query/document pair in the
+    /// reranker chat template, run the decoder, and take the softmax of the
+    /// "yes"/"no" token logits at the last real token as the relevance score.
+    ///
+    /// When the vocabulary lacks a yes/no token, returns neutral scores so the
+    /// caller's stable sort preserves the original retrieval order rather than
+    /// failing the whole search.
+    fn rerank_batch_causal(
+        &self,
+        query: &str,
+        documents: &[&str],
+    ) -> Result<Vec<f32>, DomainError> {
+        let batch_size = documents.len();
+
+        let (Some(yes_id), Some(no_id)) = (self.token_true_id, self.token_false_id) else {
+            return Ok(vec![0.5; batch_size]);
+        };
+        let (yes_id, no_id) = (yes_id as usize, no_id as usize);
+
+        let prompts: Vec<String> = documents
+            .iter()
+            .map(|doc| {
+                format!(
+                    "{QWEN_PREFIX}<Instruct>: {QWEN_INSTRUCTION}\n<Query>: {query}\n<Document>: {doc}{QWEN_SUFFIX}"
+                )
+            })
+            .collect();
+
+        // The chat-template markers (`<|im_start|>`, `<think>`, …) are added
+        // tokens the tokenizer maps directly, so no extra special tokens are
+        // injected here.
+        let encodings = self
+            .tokenizer
+            .encode_batch(prompts.iter().map(|s| s.as_str()).collect(), false)
+            .map_err(|e| DomainError::internal(format!("Tokenization failed: {}", e)))?;
+
+        let max_len = encodings
+            .iter()
+            .map(|e| e.get_ids().len())
+            .max()
+            .unwrap_or(0)
+            .min(self.max_sequence_length);
+
+        let mut input_ids: Vec<i64> = Vec::with_capacity(batch_size * max_len);
+        let mut attention_mask: Vec<i64> = Vec::with_capacity(batch_size * max_len);
+        // Index of the last real (non-padded) token per sequence; this is where
+        // a causal LM emits its answer logits.
+        let mut last_idx: Vec<usize> = Vec::with_capacity(batch_size);
+
+        for encoding in &encodings {
+            let ids = encoding.get_ids();
+            let mask = encoding.get_attention_mask();
+
+            let len = ids.len().min(max_len);
+
+            input_ids.extend(ids[..len].iter().map(|&x| x as i64));
+            attention_mask.extend(mask[..len].iter().map(|&x| x as i64));
+
+            let padding = max_len - len;
+            input_ids.extend(std::iter::repeat_n(0i64, padding));
+            attention_mask.extend(std::iter::repeat_n(0i64, padding));
+
+            last_idx.push(len.saturating_sub(1));
+        }
+
+        let shape = [batch_size, max_len];
+        let input_ids_tensor = Tensor::from_array((shape, input_ids)).map_err(|e| {
+            DomainError::internal(format!("Failed to create input_ids tensor: {}", e))
+        })?;
+        let attention_mask_tensor = Tensor::from_array((shape, attention_mask)).map_err(|e| {
+            DomainError::internal(format!("Failed to create attention_mask tensor: {}", e))
+        })?;
+
+        let mut session = self
+            .session
+            .lock()
+            .map_err(|e| DomainError::internal(format!("Failed to lock session: {}", e)))?;
+
+        let outputs = session
+            .run(ort::inputs![
+                "input_ids" => input_ids_tensor,
+                "attention_mask" => attention_mask_tensor,
+            ])
+            .map_err(|e| DomainError::internal(format!("Inference failed: {}", e)))?;
+
+        let output_value = outputs
+            .iter()
+            .next()
+            .map(|(_, v)| v)
+            .ok_or_else(|| DomainError::internal("No output tensor found"))?;
+
+        let (out_shape, data) = output_value.try_extract_tensor::<f32>().map_err(|e| {
+            DomainError::internal(format!("Failed to extract output tensor: {}", e))
+        })?;
+
+        let out_shape: Vec<usize> = out_shape.iter().map(|&x| x as usize).collect();
+        debug!("Causal reranker output shape: {:?}", out_shape);
+
+        // Expect causal LM logits: [batch, seq, vocab].
+        if out_shape.len() != 3 {
+            return Err(DomainError::internal(format!(
+                "Unexpected causal reranker output shape: {:?} (expected [batch, seq, vocab])",
+                out_shape
+            )));
+        }
+        let seq_len = out_shape[1];
+        let vocab = out_shape[2];
+        if yes_id >= vocab || no_id >= vocab {
+            return Err(DomainError::internal(format!(
+                "yes/no token id out of range for vocab {vocab}"
+            )));
+        }
+
+        let scores = (0..batch_size)
+            .map(|i| {
+                let pos = last_idx[i].min(seq_len.saturating_sub(1));
+                let row = i * seq_len * vocab + pos * vocab;
+                let yes_logit = data[row + yes_id];
+                let no_logit = data[row + no_id];
+                // Two-way softmax over the yes/no logits.
+                let m = yes_logit.max(no_logit);
+                let yes_e = (yes_logit - m).exp();
+                let no_e = (no_logit - m).exp();
+                yes_e / (yes_e + no_e)
+            })
+            .collect();
 
         Ok(scores)
     }

--- a/src/connector/api/container.rs
+++ b/src/connector/api/container.rs
@@ -72,7 +72,7 @@ pub struct ContainerConfig {
     pub llm_target: LlmTarget,
     /// Embedding model identifier.
     ///
-    /// For `Onnx`: HuggingFace model ID (default: `sentence-transformers/all-MiniLM-L6-v2`).
+    /// For `Onnx`: HuggingFace model ID (default: `Qwen/Qwen3-Embedding-0.6B`).
     /// For `Api`: model name sent in the `/v1/embeddings` request body (must match
     /// the model currently loaded in LM Studio or the target server).
     ///
@@ -80,7 +80,7 @@ pub struct ContainerConfig {
     pub embedding_model: Option<String>,
     /// Number of dimensions produced by the embedding model.
     ///
-    /// Defaults to 384 (the dimension of `all-MiniLM-L6-v2`).  Override with
+    /// Defaults to 1024 (the dimension of `Qwen/Qwen3-Embedding-0.6B`).  Override with
     /// `--embedding-dimensions` when using a model with a different output size.
     /// The value is persisted in `namespace_config` and cannot change after the
     /// namespace has been indexed — use a different namespace or re-index with
@@ -200,7 +200,7 @@ impl Container {
         let parser = Arc::new(TreeSitterParser::new());
 
         // Resolve the effective model name for the selected embedding target.
-        const ONNX_DEFAULT_MODEL: &str = "sentence-transformers/all-MiniLM-L6-v2";
+        const ONNX_DEFAULT_MODEL: &str = "Qwen/Qwen3-Embedding-0.6B";
         let effective_model = match config.embedding_model.clone() {
             Some(m) => m,
             None => match config.embedding_target {

--- a/src/connector/api/container.rs
+++ b/src/connector/api/container.rs
@@ -200,11 +200,11 @@ impl Container {
         let parser = Arc::new(TreeSitterParser::new());
 
         // Resolve the effective model name for the selected embedding target.
-        const ONNX_DEFAULT_MODEL: &str = "Qwen/Qwen3-Embedding-0.6B";
+        // The ONNX default lives on the adapter so metadata and indexing agree.
         let effective_model = match config.embedding_model.clone() {
             Some(m) => m,
             None => match config.embedding_target {
-                EmbeddingTarget::Onnx => ONNX_DEFAULT_MODEL.to_string(),
+                EmbeddingTarget::Onnx => OrtEmbedding::DEFAULT_MODEL_ID.to_string(),
                 EmbeddingTarget::Api => {
                     return Err(anyhow::anyhow!(
                         "--embedding-model is required when using --embedding-target=api"
@@ -224,7 +224,7 @@ impl Container {
                         "Initializing ONNX embedding service (model='{}')...",
                         effective_model
                     );
-                    let model_arg = if effective_model == ONNX_DEFAULT_MODEL {
+                    let model_arg = if effective_model == OrtEmbedding::DEFAULT_MODEL_ID {
                         None
                     } else {
                         Some(effective_model.as_str())

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,17 +49,17 @@ struct Cli {
     embedding_target: EmbeddingTarget,
 
     /// Embedding model identifier.
-    /// For 'onnx': HuggingFace model ID (default: sentence-transformers/all-MiniLM-L6-v2).
+    /// For 'onnx': HuggingFace model ID (default: Qwen/Qwen3-Embedding-0.6B).
     /// For 'api': model name sent in the /v1/embeddings request body; must match
     /// the model loaded in the target server (set OPENAI_BASE_URL for non-default address).
     #[arg(long, global = true)]
     embedding_model: Option<String>,
 
-    /// Number of dimensions produced by the embedding model (default: 384).
-    /// Override when using a model with a different output size (e.g. 768 or 1024).
+    /// Number of dimensions produced by the embedding model (default: 1024).
+    /// Override when using a model with a different output size (e.g. 384 or 768).
     /// This value is stored in namespace_config on first index and cannot be
     /// changed without re-indexing.
-    #[arg(long, global = true, default_value = "384")]
+    #[arg(long, global = true, default_value = "1024")]
     embedding_dimensions: usize,
 
     /// Reranking backend (used when --no-rerank is not set):
@@ -163,7 +163,7 @@ async fn main() -> Result<()> {
     // the embedding settings are adopted only when the effective namespace
     // matches the resolved one, so an explicit `--namespace <indexed-ns>` still
     // picks up that namespace's embedding config (which `Container::new`
-    // validates) instead of silently falling back to the ONNX/384 defaults.
+    // validates) instead of silently falling back to the ONNX/1024 defaults.
     let mut namespace = cli.namespace.clone();
     let mut embedding_target = cli.embedding_target;
     let mut embedding_model = cli.embedding_model.clone();


### PR DESCRIPTION
Switch the bundled defaults to the Qwen3 model family:

- ONNX embedding: Qwen/Qwen3-Embedding-0.6B (1024-dim, was
  all-MiniLM-L6-v2 at 384-dim); lower the ONNX batch size to 32 to
  bound peak memory for the heavier model.
- ONNX reranker: Qwen/Qwen3-Reranker-0.6B (was BAAI/bge-reranker-base).
- Local LLM default (query expansion / reranking / explain) for both
  the Anthropic- and OpenAI-compatible chat clients: qwen/qwen3.5-4b.

The default --embedding-dimensions is bumped 384 -> 1024 to match the
new embedding model. Docs updated to reflect the new defaults.

BREAKING CHANGE: the default embedding model and dimension count
changed, so namespaces indexed with the previous defaults must be
re-indexed (`codesearch index --force`) or pinned to the old model
via --embedding-model / --embedding-dimensions.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C5buaW2EkWg7XM39UutLXx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default embedding and reranking models to newer Qwen-based options.
  * Increased the default embedding size, improving compatibility with the new model set.
  * Added support for multiple model styles during search and reranking.

* **Documentation**
  * Refreshed setup, search, indexing, and architecture docs to match the new defaults and configuration values.
  * Updated CLI and environment variable help text to reflect the latest recommended settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->